### PR TITLE
Bump version to 0.1.9 for PyPI publishing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roe-ai"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
     { name = "Roe AI", email = "founders@roe-ai.com" },
 ]


### PR DESCRIPTION
- Updated version from 0.1.8 to 0.1.9 in pyproject.toml
- Version 0.1.8 already exists on PyPI, so incrementing for new release