### PR TITLE
feat: add retry logic for 502/503/504 and 10s batch chunk delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,9 +426,9 @@ agent = client.agents.create(
 
 ## Retry Behavior
 
-The SDK automatically retries requests that receive `502`, `503`, or `504` responses using exponential backoff (1s, 2s, 4s, …). By default, up to 3 retries are attempted before raising a `ServerError`.
+The SDK automatically retries idempotent requests (GET, PUT, DELETE) that receive `502`, `503`, or `504` responses using exponential backoff (1s, 2s, 4s, …). By default, up to 3 retries are attempted before raising a `ServerError`. POST requests are never retried to avoid duplicate submissions.
 
-You can configure this via the `max_retries` parameter or the `ROE_MAX_RETRIES` environment variable:
+You can configure the retry count via the `max_retries` parameter or the `ROE_MAX_RETRIES` environment variable:
 
 ```python
 client = RoeClient(

--- a/README.md
+++ b/README.md
@@ -424,6 +424,32 @@ agent = client.agents.create(
 )
 ```
 
+## Retry Behavior
+
+The SDK automatically retries requests that receive `502`, `503`, or `504` responses using exponential backoff (1s, 2s, 4s, …). By default, up to 3 retries are attempted before raising a `ServerError`.
+
+You can configure this via the `max_retries` parameter or the `ROE_MAX_RETRIES` environment variable:
+
+```python
+client = RoeClient(
+    api_key="your-api-key",
+    organization_id="your-org-uuid",
+    max_retries=5,  # default: 3
+)
+```
+
+Other error codes (400, 401, 404, 500, etc.) are raised immediately without retrying.
+
+## Batch Processing
+
+When batch operations exceed 1,000 items, the SDK automatically chunks requests. A 10-second delay is applied between chunks to avoid overwhelming the API. This applies to:
+
+- `client.agents.run_many()` — job submissions
+- `client.agents.jobs.retrieve_status_many()` — batch status checks
+- `client.agents.jobs.retrieve_result_many()` — batch result retrieval
+
+Single-chunk batches (≤1,000 items) are unaffected.
+
 ## Running Agents
 
 ```python

--- a/README.md
+++ b/README.md
@@ -442,13 +442,23 @@ Other error codes (400, 401, 404, 500, etc.) are raised immediately without retr
 
 ## Batch Processing
 
-When batch operations exceed 1,000 items, the SDK automatically chunks requests. A 10-second delay is applied between chunks to avoid overwhelming the API. This applies to:
+When batch operations exceed 1,000 items, the SDK automatically chunks requests. A configurable delay (default: 10 seconds) is applied between chunks to avoid overwhelming the API. This applies to:
 
 - `client.agents.run_many()` — job submissions
 - `client.agents.jobs.retrieve_status_many()` — batch status checks
 - `client.agents.jobs.retrieve_result_many()` — batch result retrieval
 
 Single-chunk batches (≤1,000 items) are unaffected.
+
+You can configure the delay via the `batch_chunk_delay` parameter or the `ROE_BATCH_CHUNK_DELAY` environment variable:
+
+```python
+client = RoeClient(
+    api_key="your-api-key",
+    organization_id="your-org-uuid",
+    batch_chunk_delay=2.0,  # default: 10.0
+)
+```
 
 ## Running Agents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roe-ai"
-version = "0.2.8"
+version = "0.2.9"
 authors = [
     { name = "Roe AI", email = "founders@roe-ai.com" },
 ]

--- a/src/roe/__init__.py
+++ b/src/roe/__init__.py
@@ -41,7 +41,7 @@ from roe.models.responses import (
     Reference,
 )
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 __all__ = [
     # Main client

--- a/src/roe/api/agents.py
+++ b/src/roe/api/agents.py
@@ -226,7 +226,7 @@ class AgentJobsAPI:
             if not chunk:
                 continue
             if not is_first_chunk:
-                time.sleep(10)
+                time.sleep(self._agents_api.config.batch_chunk_delay)
             is_first_chunk = False
             response_data = self.http_client.post(
                 "/v1/agents/jobs/statuses/", json_data={"job_ids": chunk}
@@ -251,7 +251,7 @@ class AgentJobsAPI:
             if not chunk:
                 continue
             if not is_first_chunk:
-                time.sleep(10)
+                time.sleep(self._agents_api.config.batch_chunk_delay)
             is_first_chunk = False
             response_data = self.http_client.post(
                 "/v1/agents/jobs/results/", json_data={"job_ids": chunk}
@@ -568,7 +568,7 @@ class AgentsAPI:
             if not chunk:
                 continue
             if not is_first_chunk:
-                time.sleep(10)
+                time.sleep(self.config.batch_chunk_delay)
             is_first_chunk = False
             json_data: dict[str, Any] = {"inputs": chunk}
             if metadata is not None:

--- a/src/roe/api/agents.py
+++ b/src/roe/api/agents.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from roe.config import RoeConfig
@@ -220,9 +221,13 @@ class AgentJobsAPI:
             List of AgentJobStatusBatch instances in the same order as job_ids.
         """
         results: list[AgentJobStatusBatch] = []
+        is_first_chunk = True
         for chunk in self._iter_chunks(job_ids, self._MAX_BATCH_SIZE):
             if not chunk:
                 continue
+            if not is_first_chunk:
+                time.sleep(10)
+            is_first_chunk = False
             response_data = self.http_client.post(
                 "/v1/agents/jobs/statuses/", json_data={"job_ids": chunk}
             )
@@ -241,9 +246,13 @@ class AgentJobsAPI:
             List of AgentJobResultBatch instances in the same order as job_ids.
         """
         results: list[AgentJobResultBatch] = []
+        is_first_chunk = True
         for chunk in self._iter_chunks(job_ids, self._MAX_BATCH_SIZE):
             if not chunk:
                 continue
+            if not is_first_chunk:
+                time.sleep(10)
+            is_first_chunk = False
             response_data = self.http_client.post(
                 "/v1/agents/jobs/results/", json_data={"job_ids": chunk}
             )
@@ -554,9 +563,13 @@ class AgentsAPI:
             JobBatch instance for tracking and waiting on all executions.
         """
         all_job_ids: list[str] = []
+        is_first_chunk = True
         for chunk in self._iter_chunks(batch_inputs, self._MAX_BATCH_SIZE):
             if not chunk:
                 continue
+            if not is_first_chunk:
+                time.sleep(10)
+            is_first_chunk = False
             json_data: dict[str, Any] = {"inputs": chunk}
             if metadata is not None:
                 json_data["metadata"] = metadata

--- a/src/roe/client.py
+++ b/src/roe/client.py
@@ -17,6 +17,7 @@ class RoeClient:
         base_url: str | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
+        batch_chunk_delay: float | None = None,
     ):
         """Initialize the Roe AI client.
 
@@ -26,6 +27,7 @@ class RoeClient:
             base_url: Base URL for the API. If not provided, will use ROE_BASE_URL env var or default.
             timeout: Request timeout in seconds. If not provided, will use ROE_TIMEOUT env var or default.
             max_retries: Maximum number of retries. If not provided, will use ROE_MAX_RETRIES env var or default.
+            batch_chunk_delay: Delay in seconds between batch chunk requests. If not provided, will use ROE_BATCH_CHUNK_DELAY env var or default (10.0).
 
         Raises:
             ValueError: If required parameters (api_key, organization_id) are not provided.
@@ -54,6 +56,7 @@ class RoeClient:
             base_url=base_url,
             timeout=timeout,
             max_retries=max_retries,
+            batch_chunk_delay=batch_chunk_delay,
         )
 
         # Create authentication

--- a/src/roe/config.py
+++ b/src/roe/config.py
@@ -15,6 +15,10 @@ class RoeConfig(BaseModel):
     )
     timeout: float = Field(default=60.0, description="Request timeout in seconds")
     max_retries: int = Field(default=3, description="Maximum number of retries")
+    batch_chunk_delay: float = Field(
+        default=10.0,
+        description="Delay in seconds between batch chunk requests",
+    )
 
     @classmethod
     def from_env(
@@ -24,6 +28,7 @@ class RoeConfig(BaseModel):
         base_url: str | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
+        batch_chunk_delay: float | None = None,
     ) -> "RoeConfig":
         """Create configuration from environment variables and parameters.
 
@@ -33,6 +38,7 @@ class RoeConfig(BaseModel):
             base_url: Base URL. If not provided, uses ROE_BASE_URL env var or default.
             timeout: Request timeout. If not provided, uses ROE_TIMEOUT env var or default.
             max_retries: Max retries. If not provided, uses ROE_MAX_RETRIES env var or default.
+            batch_chunk_delay: Delay between batch chunks. If not provided, uses ROE_BATCH_CHUNK_DELAY env var or default.
 
         Returns:
             RoeConfig instance.
@@ -46,6 +52,9 @@ class RoeConfig(BaseModel):
         base_url = base_url or os.getenv("ROE_BASE_URL", "https://api.roe-ai.com")
         timeout = timeout or float(os.getenv("ROE_TIMEOUT", "60.0"))
         max_retries = max_retries or int(os.getenv("ROE_MAX_RETRIES", "3"))
+        batch_chunk_delay = batch_chunk_delay if batch_chunk_delay is not None else float(
+            os.getenv("ROE_BATCH_CHUNK_DELAY", "10.0")
+        )
 
         if not api_key:
             raise ValueError(
@@ -63,4 +72,5 @@ class RoeConfig(BaseModel):
             base_url=base_url,
             timeout=timeout,
             max_retries=max_retries,
+            batch_chunk_delay=batch_chunk_delay,
         )

--- a/src/roe/utils/http_client.py
+++ b/src/roe/utils/http_client.py
@@ -2,9 +2,13 @@
 
 import io
 import json as _json
+import logging
+import time
 from typing import Any
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 from roe.auth import RoeAuth
 from roe.config import RoeConfig
@@ -123,6 +127,41 @@ class RoeHTTPClient:
             response=error_data,
         )
 
+    _RETRYABLE_STATUS_CODES = {502, 503, 504}
+
+    def _request_with_retry(self, method: str, url: str, **kwargs) -> httpx.Response:
+        """Execute an HTTP request with retries for 502/503/504 errors.
+
+        Uses exponential backoff: 1s, 2s, 4s, ...
+        Retries up to config.max_retries times (default: 3).
+        """
+        max_retries = self.config.max_retries
+        last_response = None
+
+        for attempt in range(max_retries + 1):
+            response = getattr(self.client, method)(url, **kwargs)
+
+            if response.status_code not in self._RETRYABLE_STATUS_CODES:
+                return response
+
+            last_response = response
+
+            if attempt < max_retries:
+                wait_time = 2 ** attempt  # 1, 2, 4, ...
+                logger.warning(
+                    "Roe API returned %d for %s %s, retrying in %ds (attempt %d/%d)",
+                    response.status_code,
+                    method.upper(),
+                    url,
+                    wait_time,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(wait_time)
+
+        # All retries exhausted — let _handle_response raise the exception
+        return last_response
+
     def get(self, url: str, params: dict[str, Any] | None = None) -> Any:
         """Make a GET request.
 
@@ -133,7 +172,7 @@ class RoeHTTPClient:
         Returns:
             Parsed JSON response.
         """
-        response = self.client.get(url, params=params)
+        response = self._request_with_retry("get", url, params=params)
         return self._handle_response(response)
 
     def post(
@@ -167,7 +206,7 @@ class RoeHTTPClient:
         if params:
             kwargs["params"] = params
 
-        response = self.client.post(url, **kwargs)
+        response = self._request_with_retry("post", url, **kwargs)
         return self._handle_response(response)
 
     def post_with_dynamic_inputs(
@@ -222,7 +261,7 @@ class RoeHTTPClient:
         if params:
             kwargs["params"] = params
 
-        response = self.client.put(url, **kwargs)
+        response = self._request_with_retry("put", url, **kwargs)
         return self._handle_response(response)
 
     def delete(self, url: str, params: dict[str, Any] | None = None) -> None:
@@ -238,7 +277,7 @@ class RoeHTTPClient:
         Raises:
             RoeAPIException: For API errors.
         """
-        response = self.client.delete(url, params=params)
+        response = self._request_with_retry("delete", url, params=params)
         if response.status_code == 204:
             return None
         if response.is_success:
@@ -259,7 +298,7 @@ class RoeHTTPClient:
         Raises:
             RoeAPIException: For API errors.
         """
-        response = self.client.get(url, params=params)
+        response = self._request_with_retry("get", url, params=params)
         if response.is_success:
             return response.content
 

--- a/src/roe/utils/http_client.py
+++ b/src/roe/utils/http_client.py
@@ -128,36 +128,48 @@ class RoeHTTPClient:
         )
 
     _RETRYABLE_STATUS_CODES = {502, 503, 504}
+    _IDEMPOTENT_METHODS = {"get", "put", "delete"}
 
     def _request_with_retry(self, method: str, url: str, **kwargs) -> httpx.Response:
         """Execute an HTTP request with retries for 502/503/504 errors.
 
+        Only idempotent methods (GET, PUT, DELETE) are retried. POST requests
+        are never retried to avoid duplicate submissions and file-handle
+        exhaustion on multipart uploads.
+
         Uses exponential backoff: 1s, 2s, 4s, ...
         Retries up to config.max_retries times (default: 3).
         """
-        max_retries = self.config.max_retries
-        last_response = None
+        response = getattr(self.client, method)(url, **kwargs)
 
-        for attempt in range(max_retries + 1):
+        if method not in self._IDEMPOTENT_METHODS:
+            return response
+
+        if response.status_code not in self._RETRYABLE_STATUS_CODES:
+            return response
+
+        max_retries = self.config.max_retries
+        last_response = response
+
+        for attempt in range(max_retries):
+            wait_time = 2 ** attempt  # 1, 2, 4, ...
+            logger.warning(
+                "Roe API returned %d for %s %s, retrying in %ds (attempt %d/%d)",
+                last_response.status_code,
+                method.upper(),
+                url,
+                wait_time,
+                attempt + 1,
+                max_retries,
+            )
+            time.sleep(wait_time)
+
             response = getattr(self.client, method)(url, **kwargs)
 
             if response.status_code not in self._RETRYABLE_STATUS_CODES:
                 return response
 
             last_response = response
-
-            if attempt < max_retries:
-                wait_time = 2 ** attempt  # 1, 2, 4, ...
-                logger.warning(
-                    "Roe API returned %d for %s %s, retrying in %ds (attempt %d/%d)",
-                    response.status_code,
-                    method.upper(),
-                    url,
-                    wait_time,
-                    attempt + 1,
-                    max_retries,
-                )
-                time.sleep(wait_time)
 
         # All retries exhausted — let _handle_response raise the exception
         return last_response

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "roe-ai"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Add automatic retries with exponential backoff (1s, 2s, 4s) for transient 502/503/504 errors across all HTTP methods, using the existing `config.max_retries` setting (default: 3)
- Add 10-second delay between batch chunk requests in `run_many()`, `retrieve_status_many()`, and `retrieve_result_many()` to avoid overwhelming the API
- Bump version to 0.2.9