### PR TITLE
fix: use str instead of UUID for batch job result ID fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roe-ai"
-version = "0.2.9"
+version = "0.2.10"
 authors = [
     { name = "Roe AI", email = "founders@roe-ai.com" },
 ]

--- a/src/roe/models/responses.py
+++ b/src/roe/models/responses.py
@@ -2,8 +2,6 @@
 
 import json
 from typing import Any, Generic, TypeVar
-from uuid import UUID
-
 from pydantic import BaseModel, Field
 
 T = TypeVar("T")
@@ -192,8 +190,8 @@ class AgentJobResultBatch(BaseModel):
         default=None,
         description="List of corrected outputs if any corrections were made",
     )
-    agent_id: UUID | None = Field(default=None, description="Base agent ID")
-    agent_version_id: UUID | None = Field(default=None, description="Agent version ID")
+    agent_id: str | None = Field(default=None, description="Base agent ID")
+    agent_version_id: str | None = Field(default=None, description="Agent version ID")
     cost: float | None = Field(
         default=None, description="Cost of the agent job execution"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "roe-ai"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- `AgentJobResultBatch.agent_id` and `agent_version_id` were typed as `UUID | None`, causing Pydantic v2 to parse JSON strings into `uuid.UUID` objects. When passed to `AgentJobResult` (which expects `str`), this raised a `ValidationError` during `batch.wait()`.
- Changed both fields to `str | None` to match the API wire format and the single-result model (`AgentJobResult`).
- Bumped version to `0.2.10`.

## Test plan
- [ ] Run `batch.wait()` against a live agent and confirm results deserialize without `ValidationError`
- [ ] Verify `AgentJobResult.agent_id` and `agent_version_id` are plain strings in both single and batch result paths

Made with [Cursor](https://cursor.com)