### PR TITLE
ci: use GitHub App token for tag push (so publish.yml triggers)

### DIFF
--- a/.github/workflows/tag-on-release-merge.yml
+++ b/.github/workflows/tag-on-release-merge.yml
@@ -11,10 +11,17 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SDK_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up uv and Python
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## Summary

Switch the tag-push step in `tag-on-release-merge.yml` to mint a token from the existing roe-ai GitHub App (`APP_ID` / `APP_PRIVATE_KEY` org secrets) instead of the static `secrets.SDK_RELEASE_TOKEN`, which is unset on this repo.

**Why**: GitHub's default `GITHUB_TOKEN` deliberately does not trigger downstream workflows. So if `tag-on-release-merge.yml` ever managed to run with `GITHUB_TOKEN` (or the unset `SDK_RELEASE_TOKEN` fell back to it), the pushed `vX.Y.Z` tag would not fire `publish.yml`, and no PyPI release would happen. App-installation tokens DO trigger downstream workflows, restoring the release flow.

Same change is being applied to `roe-ai/roe-typescript` and `roe-ai/roe-golang`.

## Test plan

- [ ] Org-side prereqs confirmed (one-time):
  - `APP_ID` / `APP_PRIVATE_KEY` org secrets are accessible to this repo (likely already are — roe-main's `update-sdk` job already uses them to open PRs against this repo).
  - The roe-ai GitHub App is installed on this repo with `Contents: write` (needed to push tags).
- [ ] After merge, on the next release-fan-out PR (from roe-main `update-sdk` job) merged into `main`:
  - `Mint App token` step succeeds.
  - `Create version tag` step pushes `vX.Y.Z`.
  - `Publish to PyPI` workflow runs and the new version appears at https://pypi.org/project/roe/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)