### PR TITLE
ci: disable uv cache on no-op tag-release runs

### DIFF
--- a/.github/workflows/tag-on-release-merge.yml
+++ b/.github/workflows/tag-on-release-merge.yml
@@ -27,6 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.11.9"
+          enable-cache: false
 
       - name: Read merged release version
         id: version


### PR DESCRIPTION
## Summary

Fixes false-failures on `tag-on-release-merge.yml` runs that don't bump `pyproject.toml`.

## Why it was failing

`tag-on-release-merge.yml` runs on every push to \`main\`. When the merge doesn't change \`pyproject.toml\`, \`Read merged release version\` exits early (correct) and \`Create version tag\` is skipped (correct). However, \`astral-sh/setup-uv@v6\` had already run, and its post-cleanup tries to save the uv cache. Since \`uv run\` was never actually invoked (early exit), the cache directory is empty, and post-cleanup fails:

\`\`\`
Error: Cache path /home/runner/work/_temp/setup-uv-cache does not exist on disk.
This likely indicates that there are no dependencies to cache.
\`\`\`

That single post-step failure marks the entire job red, even though the tag-skip logic worked exactly as intended.

## The fix

Add \`enable-cache: false\` to the setup-uv step. The only uv invocation in this workflow is one stdlib-only one-liner (\`import tomllib, pathlib; ...\`), so caching had no benefit anyway.

## Test plan

- [ ] After merge, a fresh push to \`main\` (e.g. this PR's merge commit, which doesn't touch \`pyproject.toml\`) runs \`tag-on-release-merge.yml\` and **completes green**, with \`Create version tag\` correctly skipped.
- [ ] On the next real release-fan-out PR (one that bumps \`pyproject.toml\`), the \`Create version tag\` step runs and pushes \`vX.Y.Z\`, triggering \`publish.yml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)