### PR TITLE
docs(readme): make Raw API example portable across codegen renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,23 @@ result["error_message"]  # Error string or None — set by Job.wait()
 
 ## Raw API Access
 
-The generated raw client is exposed as `client.raw`, and the generated package is available under `roe._generated`:
+When the ergonomic wrappers don't expose an endpoint you need, the generated
+client is available as `client.raw` and the operation modules live under
+`roe._generated.api.<tag>.<operation_id>`. Submodule names follow the
+upstream OpenAPI tags + `operationId`s and may shift across releases, so the
+portable form uses `client.raw.get_httpx_client()` to send a request through
+the same auth-configured `httpx.Client`:
 
 ```python
 from roe import RoeClient
-from roe._generated.api.v1 import v1_users_current_user_retrieve
 
 client = RoeClient(api_key="your-api-key", organization_id="your-org-uuid")
-response = v1_users_current_user_retrieve.sync_detailed(client=client.raw)
+response = client.raw.get_httpx_client().get("/v1/users/current_user/")
 print(response.status_code)
 ```
+
+For typed request/response models, call the generated operation module
+directly — see `roe/_generated/api/` for the current surface.
 
 ## Agent Examples
 


### PR DESCRIPTION
## Summary

README's "Raw API Access" example imported
`roe._generated.api.v1.v1_users_current_user_retrieve` directly. Every
shift in the upstream OpenAPI module structure / operationId names breaks
that import — the [v1.0.79 release PR #31](https://github.com/roe-ai/roe-python/pull/31)
moves `_generated/api/v1/` to per-tag directories (`agents/`, `policies/`,
`users/`) and drops the `v1_` prefix from every module, so anyone
copy-pasting from main after that release gets `ModuleNotFoundError`.

Replace the snippet with `client.raw.get_httpx_client().get(...)`, which
routes through the same auth-configured `httpx.Client` without referencing
a specific operation submodule. Closing pointer tells readers where to
look when they want the typed surface; that surface still exists, it just
isn't safe to hardcode in docs.

Pairs with [roe-main#3186](https://github.com/roe-ai/roe-main/pull/3186)
which fixes the upstream OpenAPI content-type duplication driving
greptile's P1 on PR #31 — together those land a clean, scalable v1.0.80
release for this SDK.

## Test plan

- [x] Smoke-tested the snippet against a local stdlib `http.server`:
      `Bearer test-key` forwarded, `/v1/users/current_user/` path hit,
      `status: 200 body: {"ok":1}`.
- [x] `client.raw.get_httpx_client()` resolves to the same authenticated
      `httpx.Client` instance regardless of generated module layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)