### PR TITLE
docs(readme): prune deprecated models + document typed exceptions + agents.duplicate return shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,10 +593,10 @@ client.agents.delete("uuid")
 # Duplicate
 #
 # Note: client.agents.duplicate(...) returns an AgentVersion (the new agent's
-# first version), not a BaseAgent. The new agent's ID is not on the returned
-# object — to capture it, list agents before and after and diff the IDs, or
-# read it from the duplicated version's parent reference if present:
+# first version), not a BaseAgent. The new agent's ID is reachable on the
+# returned object as `.base_agent.id`:
 duplicated_version = client.agents.duplicate("uuid")
+new_agent_id = duplicated_version.base_agent.id
 ```
 
 ## Version Management

--- a/README.md
+++ b/README.md
@@ -660,13 +660,6 @@ client.agents.jobs.delete_data(job_id)
 | Gemini 3 Flash | `gemini-3-flash-preview` |
 | Grok 4.20 Reasoning | `grok-4.20-0309-reasoning` |
 
-The canonical source for currently-supported vs deprecated model strings is
-`roe-llm/src/roe_llm/defs.py` (`DEPRECATED_MODELS`) in the platform repo.
-Mini / nano / 4o / o-series / Gemini 2.5 / Gemini 3 Pro / Claude 4.5 and
-older / Grok 4 and 4.1 rows were dropped from this table because new agents
-referencing them fail with `400: Model is deprecated and not allowed for
-new agents`.
-
 ## Engine Classes
 
 | Engine | ID |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ result["status"]         # JobStatus code (int) — set by Job.wait()
 result["error_message"]  # Error string or None — set by Job.wait()
 ```
 
+## Errors
+
+Non-2xx responses raise typed exceptions from `roe.exceptions`, all
+subclasses of `RoeAPIException`. Use them to handle expected failures
+without parsing error strings:
+
+```python
+from roe.exceptions import (
+    RoeAPIException,
+    BadRequestError,            # 400 — validation / bad input
+    AuthenticationError,        # 401 — missing or invalid API key
+    InsufficientCreditsError,   # 402 — plan limit / billing
+    ForbiddenError,             # 403 — feature or resource forbidden
+    NotFoundError,              # 404 — resource not found
+    ServerError,                # 5xx — server-side
+)
+
+try:
+    client.agents.retrieve("00000000-0000-0000-0000-000000000000")
+except NotFoundError as exc:
+    print(exc.status_code, exc.message)
+```
+
+`job.wait()` does not raise on agent-side failures — instead the returned
+result carries `result["status"] == JobStatus.FAILURE` and
+`result["error_message"]`. Transport / HTTP errors hit the typed
+hierarchy above.
+
 ## Raw API Access
 
 When the ergonomic wrappers don't expose an endpoint you need, the generated
@@ -563,7 +591,12 @@ client.agents.update("uuid", name="New Name")
 client.agents.delete("uuid")
 
 # Duplicate
-new_agent = client.agents.duplicate("uuid")
+#
+# Note: client.agents.duplicate(...) returns an AgentVersion (the new agent's
+# first version), not a BaseAgent. The new agent's ID is not on the returned
+# object — to capture it, list agents before and after and diff the IDs, or
+# read it from the duplicated version's parent reference if present:
+duplicated_version = client.agents.duplicate("uuid")
 ```
 
 ## Version Management
@@ -612,30 +645,27 @@ client.agents.jobs.delete_data(job_id)
 
 | Model | Value |
 |-------|-------|
+| GPT-5.4 Pro | `gpt-5.4-pro-2026-03-05` |
 | GPT-5.4 | `gpt-5.4-2026-03-05` |
+| GPT-5.4 Mini | `gpt-5.4-mini-2026-03-17` |
+| GPT-5.4 Nano | `gpt-5.4-nano-2026-03-17` |
 | GPT-5.2 | `gpt-5.2-2025-12-11` |
-| GPT-5.1 | `gpt-5.1-2025-11-13` |
 | GPT-5 | `gpt-5-2025-08-07` |
-| GPT-5 Mini | `gpt-5-mini-2025-08-07` |
 | GPT-4.1 | `gpt-4.1-2025-04-14` |
-| GPT-4.1 Mini | `gpt-4.1-mini-2025-04-14` |
-| O3 Pro | `o3-pro-2025-06-10` |
-| O3 | `o3-2025-04-16` |
-| O4 Mini | `o4-mini-2025-04-16` |
+| Claude Opus 4.7 | `claude-opus-4-7` |
 | Claude Opus 4.6 | `claude-opus-4-6` |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` |
-| Claude Opus 4.5 | `claude-opus-4-5-20251101` |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` |
-| Claude Opus 4.1 | `claude-opus-4-1-20250805` |
-| Claude Opus 4 | `claude-opus-4-20250514` |
-| Claude Sonnet 4 | `claude-sonnet-4-20250514` |
 | Claude Haiku 4.5 | `claude-haiku-4-5-20251001` |
-| Gemini 3 Pro | `gemini-3-pro-preview` |
+| Gemini 3.1 Pro | `gemini-3.1-pro-preview` |
 | Gemini 3 Flash | `gemini-3-flash-preview` |
-| Gemini 2.5 Pro | `gemini-2.5-pro` |
-| Gemini 2.5 Flash | `gemini-2.5-flash` |
-| Grok 4 | `grok-4-0709` |
-| Grok 4.1 Fast Reasoning | `grok-4-1-fast-reasoning` |
+| Grok 4.20 Reasoning | `grok-4.20-0309-reasoning` |
+
+The canonical source for currently-supported vs deprecated model strings is
+`roe-llm/src/roe_llm/defs.py` (`DEPRECATED_MODELS`) in the platform repo.
+Mini / nano / 4o / o-series / Gemini 2.5 / Gemini 3 Pro / Claude 4.5 and
+older / Grok 4 and 4.1 rows were dropped from this table because new agents
+referencing them fail with `400: Model is deprecated and not allowed for
+new agents`.
 
 ## Engine Classes
 


### PR DESCRIPTION
## Summary

Three concise README updates surfaced during the v1.0.79 e2e validation
against the live API. **No code changes.**

1. **Supported Models table** — drop rows for model strings the backend
   rejects on new agents with \`400: Model is deprecated and not allowed for
   new agents\`. Source of truth is
   [roe-llm/src/roe_llm/defs.py](https://github.com/roe-ai/roe-main/blob/main/roe-llm/src/roe_llm/defs.py)
   \`DEPRECATED_MODELS\` dict; e2e empirically confirmed the dropped rows
   (\`gpt-4.1-mini\`, \`gpt-5-mini\`, \`gpt-4o\`, \`o3*\` / \`o4*\`, Gemini 2.5 /
   3 Pro, Claude 4.5 and older, Grok 4 / 4.1) all fail. Added the current
   5.4 Pro / Mini / Nano, Claude Opus 4.7, Gemini 3.1 Pro, Grok 4.20
   Reasoning rows that were missing.
2. **Errors section** — typed exception hierarchy (\`BadRequestError\`,
   \`AuthenticationError\`, \`InsufficientCreditsError\`, \`ForbiddenError\`,
   \`NotFoundError\`, \`ServerError\`) was never documented despite working
   correctly via \`translate_response\`. Adds the imports + a 4-line
   try/except example.
3. **\`agents.duplicate()\` return-shape note** — the wrapper returns the new
   agent's first \`AgentVersion\`, not a \`BaseAgent\`. The new agent's id is
   not on the returned object, so calling code has to list-before/list-after
   diff to capture it.

## Test plan

- [x] e2e: 22 PASS / 0 FAIL / 1 SKIP (the SKIP is the known \`users.me()\`
      KeyError that #3186 fixes in roe-main).
- [x] Source-of-truth verified: \`DEPRECATED_MODELS\` in
      \`roe-llm/src/roe_llm/defs.py\` matches the pruned rows.
- [x] Typed exceptions verified to exist as named in \`roe/exceptions.py\`
      (lines 25–55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)