### PR TITLE
fix(codegen): regenerate _generated/ to clear check-codegen-drift on main

### DIFF
--- a/src/roe/_generated/api/agents/agents_partial_update.py
+++ b/src/roe/_generated/api/agents/agents_partial_update.py
@@ -49,7 +49,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/agents/agents_run.py
+++ b/src/roe/_generated/api/agents/agents_run.py
@@ -49,7 +49,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/agents/agents_run_async_create.py
+++ b/src/roe/_generated/api/agents/agents_run_async_create.py
@@ -48,7 +48,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/agents/agents_run_version.py
+++ b/src/roe/_generated/api/agents/agents_run_version.py
@@ -50,7 +50,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/agents/agents_run_versions_async_create.py
+++ b/src/roe/_generated/api/agents/agents_run_versions_async_create.py
@@ -49,7 +49,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/agents/agents_update.py
+++ b/src/roe/_generated/api/agents/agents_update.py
@@ -49,7 +49,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/agents/agents_versions_partial_update.py
+++ b/src/roe/_generated/api/agents/agents_versions_partial_update.py
@@ -49,7 +49,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/agents/agents_versions_update.py
+++ b/src/roe/_generated/api/agents/agents_versions_update.py
@@ -49,7 +49,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs

--- a/src/roe/_generated/api/policies/policies_partial_update.py
+++ b/src/roe/_generated/api/policies/policies_partial_update.py
@@ -48,7 +48,9 @@ def _get_kwargs(
     
     if not isinstance(body, Unset):
         _kwargs["json"] = body.to_dict()
-        headers["Content-Type"] = "application/json"
+
+
+    headers["Content-Type"] = "application/json"
 
     _kwargs["headers"] = headers
     return _kwargs


### PR DESCRIPTION
## Summary

\`main\` has been red on \`check-codegen-drift\` since the v1.0.79 release
merged earlier today.

### Root cause

The v1.0.79 release-branch fix ([roe-python #33](https://github.com/roe-ai/roe-python/pull/33))
hand-patched 9 optional-body endpoint files to move
\`headers["Content-Type"] = "application/json"\` *inside* the
\`if not isinstance(body, Unset):\` guard. That addressed a Greptile
P-level nit, but it was a manual edit to **generated code** — the
\`openapi-python-client\` template itself still emits the unconditional
pattern, so every \`scripts/generate-sdk\` run reverts it. The CI job
\`check-codegen-drift\` (which regens and \`git diff --exit-code\`s) flags
the divergence on every PR.

### Fix

Re-run \`bash scripts/generate-sdk\` and commit the result. 9 files revert
to the codegen tool's actual output. Drift goes green.

### Why this isn't a real regression

Greptile itself flagged the original concern as "**not a regression and not
triggered by any current caller**". The change only affects what \`Content-Type\`
header is set on requests *with no body*. The backend ignores Content-Type
when the body is empty, so reverting doesn't change behavior for any current
or anticipated caller.

The proper durable fix is in \`openapi-python-client\`'s template — either
upstream or via a \`custom_template_path\` override in \`openapi/config.yaml\`.
Tracked as a follow-up; not blocking.

## Test plan

- [x] Locally: \`bash scripts/generate-sdk && git diff --exit-code -- src/roe/_generated\` clean.
- [ ] On CI: \`check-codegen-drift\` job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)