### PR TITLE
[codex] Bump Python SDK version to 1.0.803

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "roe-ai"
-version = "1.0.802"
+version = "1.0.803"
 authors = [
     { name = "Roe", email = "founders@roe-ai.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ wheels = [
 
 [[package]]
 name = "roe-ai"
-version = "1.0.802"
+version = "1.0.803"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Bumps the Python SDK package version from `1.0.802` to `1.0.803` so it matches the current TypeScript and Go SDK versions.

## Changes

- Updated `pyproject.toml` package version to `1.0.803`.
- Updated the editable `roe-ai` package entry in `uv.lock` to `1.0.803`.

## Validation

- Built the wheel in an isolated temporary Python environment with `python -m build --wheel`.
- Verified generated wheel metadata reports `Name: roe-ai` and `Version: 1.0.803`.

Note: `dist/` is ignored by the repository, so the rebuilt wheel was not committed.
