### PR TITLE
[codex] Add Roe table upload CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ upload = client.tables.upload(
 ```
 <!-- ROE-SDK:GENERATED-FRIENDLY-APIS:END -->
 
+## CLI
+
+The `roe-ai` package installs a small `roe` command for local workflows:
+
+```bash
+roe auth login
+roe table upload ./flights.csv --table flights --wait --json
+roe table status <upload_id> --json
+```
+
+Use `roe table upload` for large local CSVs. It creates a presigned upload
+session, streams file bytes directly to Roe storage, completes the import, and
+can poll until the table is ready.
+
 ## Agent Examples
 
 ### Multimodal Extraction

--- a/openapi/wrappers.yml
+++ b/openapi/wrappers.yml
@@ -29,6 +29,8 @@ apis:
   tables:
     class_name: TablesAPI
     docstring: API for uploading CSV files into Roe tables.
+    mixins:
+    - roe.api.table_upload_helpers.TableUploadHelpersMixin
     operations:
     - kind: table_upload
       method_name: upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
 Homepage = "https://github.com/roe-ai/roe-python"
 Repository = "https://github.com/roe-ai/roe-python"
 
+[project.scripts]
+roe = "roe.cli:main"
+
 [build-system]
 requires = ["uv_build"]
 build-backend = "uv_build"

--- a/scripts/generate_wrappers.py
+++ b/scripts/generate_wrappers.py
@@ -235,6 +235,9 @@ def _table_upload_method(operation: dict[str, Any]) -> str:
 def _render_api_module(api_name: str, spec: dict[str, Any]) -> str:
     class_name = spec["class_name"]
     operations = spec.get("operations") or []
+    mixin_imports = [
+        _class_import_parts(import_path) for import_path in spec.get("mixins", [])
+    ]
 
     endpoint_imports: dict[str, list[str]] = defaultdict(list)
     model_imports: dict[str, list[str]] = defaultdict(list)
@@ -291,6 +294,8 @@ def _render_api_module(api_name: str, spec: dict[str, Any]) -> str:
     for module, names in sorted(model_imports.items()):
         joined = ", ".join(sorted(set(names)))
         lines.append(f"from {module} import {joined}\n")
+    for module, mixin_class in sorted(mixin_imports):
+        lines.append(f"from {module} import {mixin_class}\n")
     if needs_table_upload_helpers:
         lines.append("from roe._generated.types import File, UNSET, Unset\n")
     elif needs_unset:
@@ -304,7 +309,11 @@ def _render_api_module(api_name: str, spec: dict[str, Any]) -> str:
         lines.append("from roe.models import FileUpload\n")
 
     lines.append("\n\n")
-    lines.append(f"class {class_name}:\n")
+    base_classes = ", ".join(mixin_class for _, mixin_class in mixin_imports)
+    if base_classes:
+        lines.append(f"class {class_name}({base_classes}):\n")
+    else:
+        lines.append(f"class {class_name}:\n")
     lines.append(f'    """{spec.get("docstring", "")}"""\n')
     lines.append("\n")
     lines.append(

--- a/src/roe/api/table_upload_helpers.py
+++ b/src/roe/api/table_upload_helpers.py
@@ -1,0 +1,235 @@
+"""Large table upload helpers for the generated tables facade."""
+
+from __future__ import annotations
+
+import mimetypes
+import time
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import httpx
+
+from roe.exceptions import RoeAPIException, translate_response
+
+TERMINAL_UPLOAD_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED"})
+PRESIGNED_UPLOAD_TIMEOUT_SECONDS = 300.0
+PRESIGNED_UPLOAD_MAX_RETRIES = 2
+PRESIGNED_UPLOAD_RETRY_STATUSES = frozenset({500, 502, 503, 504})
+FORBIDDEN_PRESIGNED_HEADERS = {
+    "authorization",
+    "x-organization-id",
+    "x-roe-organization-id",
+}
+
+
+class TableUploadHelpersMixin:
+    """Presigned-upload helpers composed into ``TablesAPI`` by codegen."""
+
+    def create_upload(
+        self,
+        *,
+        table_name: str,
+        filename: str,
+        content_type: str = "text/csv",
+        with_headers: bool = True,
+        organization_id: str | UUID | None = None,
+    ) -> dict[str, Any]:
+        """Create a presigned CSV upload session and return the PUT URL."""
+        resolved_org = organization_id or self.config.organization_id
+        return self._request_json(
+            "POST",
+            "/v1/tables/upload/presigned-url/",
+            json_body=_compact_dict(
+                {
+                    "table_name": table_name,
+                    "filename": filename,
+                    "content_type": content_type,
+                    "with_headers": with_headers,
+                    "organization_id": str(resolved_org) if resolved_org else None,
+                }
+            ),
+            expected_status={200, 201},
+        )
+
+    def complete_upload(self, *, upload_id: str | UUID) -> dict[str, Any]:
+        """Start importing a previously uploaded presigned CSV object."""
+        upload_id = _coerce_upload_id(upload_id)
+        return self._request_json(
+            "POST",
+            f"/v1/tables/upload/{upload_id}/complete/",
+            expected_status={200, 201, 202},
+        )
+
+    def upload_status(self, *, upload_id: str | UUID) -> dict[str, Any]:
+        """Return the current status for a table upload session."""
+        upload_id = _coerce_upload_id(upload_id)
+        return self._request_json(
+            "GET",
+            f"/v1/tables/upload/{upload_id}/status/",
+            expected_status={200},
+        )
+
+    def upload_large(
+        self,
+        file: str | Path,
+        *,
+        table_name: str,
+        with_headers: bool = True,
+        wait: bool = False,
+        poll_interval: float = 2.0,
+        timeout: float | None = None,
+        organization_id: str | UUID | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload a local CSV through the presigned storage path."""
+        path = Path(file)
+        if not path.is_file():
+            raise FileNotFoundError(f"CSV file not found: {path}")
+
+        effective_filename = filename or path.name
+        content_type = _mime_type(effective_filename, mime_type)
+        created = self.create_upload(
+            table_name=table_name,
+            filename=effective_filename,
+            content_type=content_type,
+            with_headers=with_headers,
+            organization_id=organization_id,
+        )
+        _put_presigned_upload(
+            upload_url=created["upload_url"],
+            headers=created.get("headers") or {},
+            file_path=path,
+        )
+        completed = self.complete_upload(upload_id=created["upload_id"])
+        if not wait or completed.get("status") in TERMINAL_UPLOAD_STATUSES:
+            return completed
+        return self.wait_for_upload(
+            upload_id=created["upload_id"],
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+
+    def wait_for_upload(
+        self,
+        *,
+        upload_id: str | UUID,
+        poll_interval: float = 2.0,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Poll a table upload session until it reaches a terminal status."""
+        upload_id = _coerce_upload_id(upload_id)
+        if poll_interval <= 0:
+            raise ValueError("poll_interval must be greater than 0")
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        while True:
+            result = self.upload_status(upload_id=upload_id)
+            if result.get("status") in TERMINAL_UPLOAD_STATUSES:
+                return result
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(f"Timed out waiting for table upload {upload_id}")
+            sleep_for = poll_interval
+            if deadline is not None:
+                sleep_for = min(sleep_for, max(0.0, deadline - time.monotonic()))
+            time.sleep(sleep_for)
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        expected_status: set[int],
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        if json_body is not None:
+            kwargs["json"] = json_body
+        response = self._raw.get_httpx_client().request(method, path, **kwargs)
+        if response.status_code not in expected_status:
+            translate_response(response)
+            raise RoeAPIException(
+                f"{method} {path} returned unexpected HTTP {response.status_code}",
+                status_code=response.status_code,
+                headers=response.headers,
+            )
+        if not response.content:
+            return {}
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RoeAPIException(
+                f"{method} {path} returned non-JSON body: {response.text!r}",
+                status_code=response.status_code,
+                headers=response.headers,
+            ) from exc
+        if not isinstance(data, dict):
+            raise RoeAPIException(
+                f"{method} {path} returned unexpected response shape: {data!r}",
+                status_code=response.status_code,
+                headers=response.headers,
+            )
+        return data
+
+
+def _mime_type(filename: str, override: str | None) -> str:
+    if override:
+        return override
+    guessed, _ = mimetypes.guess_type(filename)
+    return guessed or "text/csv"
+
+
+def _compact_dict(data: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def _coerce_upload_id(upload_id: str | UUID) -> str:
+    return str(UUID(str(upload_id)))
+
+
+def _put_presigned_upload(
+    *,
+    upload_url: str,
+    headers: dict[str, str],
+    file_path: Path,
+) -> None:
+    clean_headers = {
+        str(key): str(value)
+        for key, value in headers.items()
+        if str(key).lower() not in FORBIDDEN_PRESIGNED_HEADERS
+    }
+    clean_headers.setdefault("Content-Length", str(file_path.stat().st_size))
+    timeout = httpx.Timeout(
+        PRESIGNED_UPLOAD_TIMEOUT_SECONDS,
+        connect=30.0,
+        read=60.0,
+        write=PRESIGNED_UPLOAD_TIMEOUT_SECONDS,
+    )
+    last_error: httpx.TransportError | None = None
+    for attempt in range(PRESIGNED_UPLOAD_MAX_RETRIES + 1):
+        try:
+            with file_path.open("rb") as payload, httpx.Client(
+                timeout=timeout,
+                trust_env=False,
+            ) as client:
+                response = client.put(
+                    upload_url,
+                    headers=clean_headers,
+                    content=payload,
+                )
+        except httpx.TransportError as exc:
+            last_error = exc
+            if attempt >= PRESIGNED_UPLOAD_MAX_RETRIES:
+                raise RoeAPIException(f"presigned upload failed: {exc}") from exc
+            time.sleep(2**attempt)
+            continue
+        if (
+            response.status_code in PRESIGNED_UPLOAD_RETRY_STATUSES
+            and attempt < PRESIGNED_UPLOAD_MAX_RETRIES
+        ):
+            time.sleep(2**attempt)
+            continue
+        translate_response(response)
+        return
+    if last_error is not None:
+        raise RoeAPIException(f"presigned upload failed: {last_error}") from last_error

--- a/src/roe/api/table_upload_helpers.py
+++ b/src/roe/api/table_upload_helpers.py
@@ -13,6 +13,7 @@ import httpx
 from roe.exceptions import RoeAPIException, translate_response
 
 TERMINAL_UPLOAD_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED"})
+FAILED_UPLOAD_STATUSES = frozenset({"FAILED", "EXPIRED"})
 PRESIGNED_UPLOAD_TIMEOUT_SECONDS = 300.0
 PRESIGNED_UPLOAD_MAX_RETRIES = 2
 PRESIGNED_UPLOAD_RETRY_STATUSES = frozenset({500, 502, 503, 504})
@@ -77,7 +78,7 @@ class TableUploadHelpersMixin:
         table_name: str,
         with_headers: bool = True,
         wait: bool = False,
-        poll_interval: float = 2.0,
+        interval: float = 2.0,
         timeout: float | None = None,
         organization_id: str | UUID | None = None,
         filename: str | None = None,
@@ -87,6 +88,10 @@ class TableUploadHelpersMixin:
         path = Path(file)
         if not path.is_file():
             raise FileNotFoundError(f"CSV file not found: {path}")
+        # Validate wait arguments before any side effects: the upload and
+        # import would otherwise proceed while the caller sees a failure.
+        if wait and interval <= 0:
+            raise ValueError("interval must be greater than 0")
 
         effective_filename = filename or path.name
         content_type = _mime_type(effective_filename, mime_type)
@@ -107,7 +112,7 @@ class TableUploadHelpersMixin:
             return completed
         return self.wait_for_upload(
             upload_id=created["upload_id"],
-            poll_interval=poll_interval,
+            interval=interval,
             timeout=timeout,
         )
 
@@ -115,13 +120,13 @@ class TableUploadHelpersMixin:
         self,
         *,
         upload_id: str | UUID,
-        poll_interval: float = 2.0,
+        interval: float = 2.0,
         timeout: float | None = None,
     ) -> dict[str, Any]:
         """Poll a table upload session until it reaches a terminal status."""
         upload_id = _coerce_upload_id(upload_id)
-        if poll_interval <= 0:
-            raise ValueError("poll_interval must be greater than 0")
+        if interval <= 0:
+            raise ValueError("interval must be greater than 0")
         deadline = time.monotonic() + timeout if timeout is not None else None
         while True:
             result = self.upload_status(upload_id=upload_id)
@@ -129,7 +134,7 @@ class TableUploadHelpersMixin:
                 return result
             if deadline is not None and time.monotonic() >= deadline:
                 raise TimeoutError(f"Timed out waiting for table upload {upload_id}")
-            sleep_for = poll_interval
+            sleep_for = interval
             if deadline is not None:
                 sleep_for = min(sleep_for, max(0.0, deadline - time.monotonic()))
             time.sleep(sleep_for)
@@ -205,7 +210,6 @@ def _put_presigned_upload(
         read=60.0,
         write=PRESIGNED_UPLOAD_TIMEOUT_SECONDS,
     )
-    last_error: httpx.TransportError | None = None
     for attempt in range(PRESIGNED_UPLOAD_MAX_RETRIES + 1):
         try:
             with file_path.open("rb") as payload, httpx.Client(
@@ -218,7 +222,6 @@ def _put_presigned_upload(
                     content=payload,
                 )
         except httpx.TransportError as exc:
-            last_error = exc
             if attempt >= PRESIGNED_UPLOAD_MAX_RETRIES:
                 raise RoeAPIException(f"presigned upload failed: {exc}") from exc
             time.sleep(2**attempt)
@@ -231,5 +234,3 @@ def _put_presigned_upload(
             continue
         translate_response(response)
         return
-    if last_error is not None:
-        raise RoeAPIException(f"presigned upload failed: {last_error}") from last_error

--- a/src/roe/api/tables.py
+++ b/src/roe/api/tables.py
@@ -5,11 +5,14 @@
 
 from __future__ import annotations
 
-from io import BytesIO
 import mimetypes
+import time
+from io import BytesIO
 from pathlib import Path
-from typing import BinaryIO
+from typing import Any, BinaryIO
 from uuid import UUID
+
+import httpx
 
 from roe._generated.api.tables import upload_table
 from roe._generated.client import AuthenticatedClient
@@ -19,6 +22,9 @@ from roe._generated.types import File, UNSET, Unset
 from roe.config import RoeConfig
 from roe.exceptions import RoeAPIException, translate_response
 from roe.models import FileUpload
+
+TERMINAL_UPLOAD_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED"})
+PRESIGNED_UPLOAD_TIMEOUT_SECONDS = 300.0
 
 
 class TablesAPI:
@@ -68,6 +74,153 @@ class TablesAPI:
         finally:
             if close_after:
                 upload_file.payload.close()
+
+    def create_upload(
+        self,
+        *,
+        table_name: str,
+        filename: str,
+        content_type: str = "text/csv",
+        with_headers: bool = True,
+        organization_id: str | UUID | None = None,
+    ) -> dict[str, Any]:
+        """Create a presigned CSV upload session and return the PUT URL."""
+        resolved_org = organization_id or self.config.organization_id
+        return self._request_json(
+            "POST",
+            "/v1/tables/upload/presigned-url/",
+            json_body=_compact_dict(
+                {
+                    "table_name": table_name,
+                    "filename": filename,
+                    "content_type": content_type,
+                    "with_headers": with_headers,
+                    "organization_id": str(resolved_org) if resolved_org else None,
+                }
+            ),
+            expected_status={200, 201},
+        )
+
+    def complete_upload(self, *, upload_id: str | UUID) -> dict[str, Any]:
+        """Start importing a previously uploaded presigned CSV object."""
+        return self._request_json(
+            "POST",
+            f"/v1/tables/upload/{upload_id}/complete/",
+            expected_status={200, 201, 202},
+        )
+
+    def upload_status(self, *, upload_id: str | UUID) -> dict[str, Any]:
+        """Return the current status for a table upload session."""
+        return self._request_json(
+            "GET",
+            f"/v1/tables/upload/{upload_id}/status/",
+            expected_status={200},
+        )
+
+    def upload_large(
+        self,
+        file: str | Path,
+        *,
+        table_name: str,
+        with_headers: bool = True,
+        wait: bool = False,
+        poll_interval: float = 2.0,
+        timeout: float | None = None,
+        organization_id: str | UUID | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload a local CSV through the presigned storage path.
+
+        This is the recommended SDK path for large local files because bytes
+        stream directly to Roe storage instead of proxying through the Roe API
+        process.
+        """
+        path = Path(file)
+        if not path.is_file():
+            raise FileNotFoundError(f"CSV file not found: {path}")
+
+        effective_filename = filename or path.name
+        content_type = _mime_type(effective_filename, mime_type)
+        created = self.create_upload(
+            table_name=table_name,
+            filename=effective_filename,
+            content_type=content_type,
+            with_headers=with_headers,
+            organization_id=organization_id,
+        )
+        _put_presigned_upload(
+            upload_url=created["upload_url"],
+            headers=created.get("headers") or {},
+            file_path=path,
+        )
+        completed = self.complete_upload(upload_id=created["upload_id"])
+        if not wait or completed.get("status") in TERMINAL_UPLOAD_STATUSES:
+            return completed
+        return self.wait_for_upload(
+            upload_id=created["upload_id"],
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+
+    def wait_for_upload(
+        self,
+        *,
+        upload_id: str | UUID,
+        poll_interval: float = 2.0,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Poll a table upload session until it reaches a terminal status."""
+        if poll_interval <= 0:
+            raise ValueError("poll_interval must be greater than 0")
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        while True:
+            result = self.upload_status(upload_id=upload_id)
+            if result.get("status") in TERMINAL_UPLOAD_STATUSES:
+                return result
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(f"Timed out waiting for table upload {upload_id}")
+            sleep_for = poll_interval
+            if deadline is not None:
+                sleep_for = min(sleep_for, max(0.0, deadline - time.monotonic()))
+            time.sleep(sleep_for)
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        expected_status: set[int],
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        if json_body is not None:
+            kwargs["json"] = json_body
+        response = self._raw.get_httpx_client().request(method, path, **kwargs)
+        if response.status_code not in expected_status:
+            translate_response(response)
+            raise RoeAPIException(
+                f"{method} {path} returned unexpected HTTP {response.status_code}",
+                status_code=response.status_code,
+                headers=response.headers,
+            )
+        if not response.content:
+            return {}
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RoeAPIException(
+                f"{method} {path} returned non-JSON body: {response.text!r}",
+                status_code=response.status_code,
+                headers=response.headers,
+            ) from exc
+        if not isinstance(data, dict):
+            raise RoeAPIException(
+                f"{method} {path} returned unexpected response shape: {data!r}",
+                status_code=response.status_code,
+                headers=response.headers,
+            )
+        return data
 
     @staticmethod
     def _as_generated_file(
@@ -128,3 +281,26 @@ def _mime_type(filename: str, override: str | None) -> str:
         return override
     guessed, _ = mimetypes.guess_type(filename)
     return guessed or "text/csv"
+
+
+def _compact_dict(data: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def _put_presigned_upload(
+    *,
+    upload_url: str,
+    headers: dict[str, str],
+    file_path: Path,
+) -> None:
+    clean_headers = {str(key): str(value) for key, value in headers.items()}
+    clean_headers.setdefault("Content-Length", str(file_path.stat().st_size))
+    timeout = httpx.Timeout(
+        PRESIGNED_UPLOAD_TIMEOUT_SECONDS,
+        connect=30.0,
+        read=60.0,
+        write=PRESIGNED_UPLOAD_TIMEOUT_SECONDS,
+    )
+    with file_path.open("rb") as payload, httpx.Client(timeout=timeout) as client:
+        response = client.put(upload_url, headers=clean_headers, content=payload)
+    translate_response(response)

--- a/src/roe/api/tables.py
+++ b/src/roe/api/tables.py
@@ -5,29 +5,24 @@
 
 from __future__ import annotations
 
-import mimetypes
-import time
 from io import BytesIO
+import mimetypes
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import BinaryIO
 from uuid import UUID
-
-import httpx
 
 from roe._generated.api.tables import upload_table
 from roe._generated.client import AuthenticatedClient
 from roe._generated.models.table_upload_request import TableUploadRequest
 from roe._generated.models.table_upload_response import TableUploadResponse
+from roe.api.table_upload_helpers import TableUploadHelpersMixin
 from roe._generated.types import File, UNSET, Unset
 from roe.config import RoeConfig
 from roe.exceptions import RoeAPIException, translate_response
 from roe.models import FileUpload
 
-TERMINAL_UPLOAD_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED"})
-PRESIGNED_UPLOAD_TIMEOUT_SECONDS = 300.0
 
-
-class TablesAPI:
+class TablesAPI(TableUploadHelpersMixin):
     """API for uploading CSV files into Roe tables."""
 
     def __init__(self, config: RoeConfig, raw_client: AuthenticatedClient):
@@ -74,153 +69,6 @@ class TablesAPI:
         finally:
             if close_after:
                 upload_file.payload.close()
-
-    def create_upload(
-        self,
-        *,
-        table_name: str,
-        filename: str,
-        content_type: str = "text/csv",
-        with_headers: bool = True,
-        organization_id: str | UUID | None = None,
-    ) -> dict[str, Any]:
-        """Create a presigned CSV upload session and return the PUT URL."""
-        resolved_org = organization_id or self.config.organization_id
-        return self._request_json(
-            "POST",
-            "/v1/tables/upload/presigned-url/",
-            json_body=_compact_dict(
-                {
-                    "table_name": table_name,
-                    "filename": filename,
-                    "content_type": content_type,
-                    "with_headers": with_headers,
-                    "organization_id": str(resolved_org) if resolved_org else None,
-                }
-            ),
-            expected_status={200, 201},
-        )
-
-    def complete_upload(self, *, upload_id: str | UUID) -> dict[str, Any]:
-        """Start importing a previously uploaded presigned CSV object."""
-        return self._request_json(
-            "POST",
-            f"/v1/tables/upload/{upload_id}/complete/",
-            expected_status={200, 201, 202},
-        )
-
-    def upload_status(self, *, upload_id: str | UUID) -> dict[str, Any]:
-        """Return the current status for a table upload session."""
-        return self._request_json(
-            "GET",
-            f"/v1/tables/upload/{upload_id}/status/",
-            expected_status={200},
-        )
-
-    def upload_large(
-        self,
-        file: str | Path,
-        *,
-        table_name: str,
-        with_headers: bool = True,
-        wait: bool = False,
-        poll_interval: float = 2.0,
-        timeout: float | None = None,
-        organization_id: str | UUID | None = None,
-        filename: str | None = None,
-        mime_type: str | None = None,
-    ) -> dict[str, Any]:
-        """Upload a local CSV through the presigned storage path.
-
-        This is the recommended SDK path for large local files because bytes
-        stream directly to Roe storage instead of proxying through the Roe API
-        process.
-        """
-        path = Path(file)
-        if not path.is_file():
-            raise FileNotFoundError(f"CSV file not found: {path}")
-
-        effective_filename = filename or path.name
-        content_type = _mime_type(effective_filename, mime_type)
-        created = self.create_upload(
-            table_name=table_name,
-            filename=effective_filename,
-            content_type=content_type,
-            with_headers=with_headers,
-            organization_id=organization_id,
-        )
-        _put_presigned_upload(
-            upload_url=created["upload_url"],
-            headers=created.get("headers") or {},
-            file_path=path,
-        )
-        completed = self.complete_upload(upload_id=created["upload_id"])
-        if not wait or completed.get("status") in TERMINAL_UPLOAD_STATUSES:
-            return completed
-        return self.wait_for_upload(
-            upload_id=created["upload_id"],
-            poll_interval=poll_interval,
-            timeout=timeout,
-        )
-
-    def wait_for_upload(
-        self,
-        *,
-        upload_id: str | UUID,
-        poll_interval: float = 2.0,
-        timeout: float | None = None,
-    ) -> dict[str, Any]:
-        """Poll a table upload session until it reaches a terminal status."""
-        if poll_interval <= 0:
-            raise ValueError("poll_interval must be greater than 0")
-        deadline = time.monotonic() + timeout if timeout is not None else None
-        while True:
-            result = self.upload_status(upload_id=upload_id)
-            if result.get("status") in TERMINAL_UPLOAD_STATUSES:
-                return result
-            if deadline is not None and time.monotonic() >= deadline:
-                raise TimeoutError(f"Timed out waiting for table upload {upload_id}")
-            sleep_for = poll_interval
-            if deadline is not None:
-                sleep_for = min(sleep_for, max(0.0, deadline - time.monotonic()))
-            time.sleep(sleep_for)
-
-    def _request_json(
-        self,
-        method: str,
-        path: str,
-        *,
-        json_body: dict[str, Any] | None = None,
-        expected_status: set[int],
-    ) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {}
-        if json_body is not None:
-            kwargs["json"] = json_body
-        response = self._raw.get_httpx_client().request(method, path, **kwargs)
-        if response.status_code not in expected_status:
-            translate_response(response)
-            raise RoeAPIException(
-                f"{method} {path} returned unexpected HTTP {response.status_code}",
-                status_code=response.status_code,
-                headers=response.headers,
-            )
-        if not response.content:
-            return {}
-        try:
-            data = response.json()
-        except ValueError as exc:
-            raise RoeAPIException(
-                f"{method} {path} returned non-JSON body: {response.text!r}",
-                status_code=response.status_code,
-                headers=response.headers,
-            ) from exc
-        if not isinstance(data, dict):
-            raise RoeAPIException(
-                f"{method} {path} returned unexpected response shape: {data!r}",
-                status_code=response.status_code,
-                headers=response.headers,
-            )
-        return data
 
     @staticmethod
     def _as_generated_file(
@@ -281,26 +129,3 @@ def _mime_type(filename: str, override: str | None) -> str:
         return override
     guessed, _ = mimetypes.guess_type(filename)
     return guessed or "text/csv"
-
-
-def _compact_dict(data: dict[str, Any]) -> dict[str, Any]:
-    return {key: value for key, value in data.items() if value is not None}
-
-
-def _put_presigned_upload(
-    *,
-    upload_url: str,
-    headers: dict[str, str],
-    file_path: Path,
-) -> None:
-    clean_headers = {str(key): str(value) for key, value in headers.items()}
-    clean_headers.setdefault("Content-Length", str(file_path.stat().st_size))
-    timeout = httpx.Timeout(
-        PRESIGNED_UPLOAD_TIMEOUT_SECONDS,
-        connect=30.0,
-        read=60.0,
-        write=PRESIGNED_UPLOAD_TIMEOUT_SECONDS,
-    )
-    with file_path.open("rb") as payload, httpx.Client(timeout=timeout) as client:
-        response = client.put(upload_url, headers=clean_headers, content=payload)
-    translate_response(response)

--- a/src/roe/auth.py
+++ b/src/roe/auth.py
@@ -22,5 +22,7 @@ class RoeAuth:
         """
         return {
             "Authorization": f"Bearer {self.config.api_key}",
+            "X-Organization-Id": self.config.organization_id,
+            "X-Roe-Organization-Id": self.config.organization_id,
             "User-Agent": "roe-python/0.1.0",
         }

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -1,0 +1,338 @@
+"""Command-line interface for the Roe SDK."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+from roe.client import RoeClient
+from roe.exceptions import RoeAPIException
+
+DEFAULT_BASE_URL = "https://api.roe-ai.com"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args) or 0)
+    except (RoeAPIException, FileNotFoundError, TimeoutError, ValueError) as exc:
+        _print_error(exc)
+        return 1
+    except KeyboardInterrupt:
+        print("Interrupted", file=sys.stderr)
+        return 130
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="roe",
+        description="Roe AI command-line tools.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    auth = subparsers.add_parser("auth", help="Manage Roe CLI authentication.")
+    auth_subparsers = auth.add_subparsers(dest="auth_command", required=True)
+
+    login = auth_subparsers.add_parser(
+        "login",
+        help="Store Roe API credentials for CLI commands.",
+    )
+    _add_connection_options(login)
+    login.set_defaults(func=_cmd_auth_login)
+
+    whoami = auth_subparsers.add_parser(
+        "whoami",
+        help="Show the authenticated Roe user.",
+    )
+    _add_connection_options(whoami)
+    whoami.add_argument("--json", action="store_true", help="Print JSON output.")
+    whoami.set_defaults(func=_cmd_auth_whoami)
+
+    table = subparsers.add_parser("table", help="Manage Roe tables.")
+    table_subparsers = table.add_subparsers(dest="table_command", required=True)
+
+    upload = table_subparsers.add_parser(
+        "upload",
+        help="Upload a local CSV as a Roe table.",
+    )
+    _add_connection_options(upload)
+    upload.add_argument("path", help="Local CSV file path.")
+    upload.add_argument(
+        "--table",
+        required=True,
+        dest="table_name",
+        help="Roe table name to create.",
+    )
+    upload.add_argument(
+        "--no-headers",
+        action="store_false",
+        dest="with_headers",
+        help="Treat every CSV row as data and generate column_1, column_2, etc.",
+    )
+    upload.add_argument(
+        "--wait", action="store_true", help="Poll until import finishes."
+    )
+    upload.add_argument(
+        "--poll-interval",
+        type=float,
+        default=2.0,
+        help="Seconds between status checks when --wait is used.",
+    )
+    upload.add_argument(
+        "--upload-timeout",
+        type=float,
+        default=None,
+        help="Maximum seconds to wait for import completion.",
+    )
+    upload.add_argument("--json", action="store_true", help="Print JSON output.")
+    upload.set_defaults(func=_cmd_table_upload)
+
+    status_cmd = table_subparsers.add_parser(
+        "status",
+        help="Show a table upload/import status.",
+    )
+    _add_connection_options(status_cmd)
+    status_cmd.add_argument("upload_id", help="Upload session ID.")
+    status_cmd.add_argument("--json", action="store_true", help="Print JSON output.")
+    status_cmd.set_defaults(func=_cmd_table_status)
+
+    return parser
+
+
+def _add_connection_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--api-key", help="Roe API key. Defaults to ROE_API_KEY/config."
+    )
+    parser.add_argument(
+        "--organization-id",
+        help="Roe organization ID. Defaults to ROE_ORGANIZATION_ID/config.",
+    )
+    parser.add_argument(
+        "--base-url",
+        help=f"Roe API base URL. Defaults to ROE_BASE_URL/config or {DEFAULT_BASE_URL}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="HTTP timeout in seconds. Defaults to ROE_TIMEOUT/config.",
+    )
+
+
+def _cmd_auth_login(args: argparse.Namespace) -> int:
+    config = _load_cli_config()
+    api_key = _first_present(
+        args.api_key, os.getenv("ROE_API_KEY"), config.get("api_key")
+    )
+    organization_id = _first_present(
+        args.organization_id,
+        os.getenv("ROE_ORGANIZATION_ID"),
+        config.get("organization_id"),
+    )
+    base_url = _first_present(
+        args.base_url,
+        os.getenv("ROE_BASE_URL"),
+        config.get("base_url"),
+        DEFAULT_BASE_URL,
+    )
+
+    if not api_key:
+        api_key = _prompt_secret("Roe API key: ")
+    if not organization_id:
+        organization_id = _prompt_text("Roe organization ID: ")
+
+    next_config = {
+        "api_key": api_key,
+        "organization_id": organization_id,
+        "base_url": base_url,
+    }
+    if args.timeout is not None:
+        next_config["timeout"] = args.timeout
+    elif config.get("timeout") is not None:
+        next_config["timeout"] = config["timeout"]
+    _save_cli_config(next_config)
+    print(f"Saved Roe credentials to {_config_path()}")
+    return 0
+
+
+def _cmd_auth_whoami(args: argparse.Namespace) -> int:
+    with _new_client(args) as client:
+        result = client.users.me()
+    _print_result(result, as_json=args.json)
+    return 0
+
+
+def _cmd_table_upload(args: argparse.Namespace) -> int:
+    with _new_client(args) as client:
+        result = client.tables.upload_large(
+            args.path,
+            table_name=args.table_name,
+            with_headers=args.with_headers,
+            wait=args.wait,
+            poll_interval=args.poll_interval,
+            timeout=args.upload_timeout,
+        )
+    _print_result(result, as_json=args.json)
+    if not args.json and result.get("status") == "IMPORTING":
+        print(f"Status: roe table status {result['upload_id']} --json")
+    return 0
+
+
+def _cmd_table_status(args: argparse.Namespace) -> int:
+    with _new_client(args) as client:
+        result = client.tables.upload_status(upload_id=args.upload_id)
+    _print_result(result, as_json=args.json)
+    return 0
+
+
+def _new_client(args: argparse.Namespace) -> RoeClient:
+    config = _connection_config(args)
+    return RoeClient(
+        api_key=config["api_key"],
+        organization_id=config["organization_id"],
+        base_url=config["base_url"],
+        timeout=config.get("timeout"),
+    )
+
+
+def _connection_config(args: argparse.Namespace) -> dict[str, Any]:
+    config = _load_cli_config()
+    api_key = _first_present(
+        args.api_key, os.getenv("ROE_API_KEY"), config.get("api_key")
+    )
+    organization_id = _first_present(
+        args.organization_id,
+        os.getenv("ROE_ORGANIZATION_ID"),
+        config.get("organization_id"),
+    )
+    base_url = _first_present(
+        args.base_url,
+        os.getenv("ROE_BASE_URL"),
+        config.get("base_url"),
+        DEFAULT_BASE_URL,
+    )
+    timeout = _first_present(
+        args.timeout,
+        _parse_float_env("ROE_TIMEOUT"),
+        config.get("timeout"),
+    )
+    if not api_key:
+        raise ValueError(
+            "Missing Roe API key. Run `roe auth login` or set ROE_API_KEY."
+        )
+    if not organization_id:
+        raise ValueError(
+            "Missing Roe organization ID. Run `roe auth login` or set ROE_ORGANIZATION_ID."
+        )
+    return {
+        "api_key": api_key,
+        "organization_id": organization_id,
+        "base_url": base_url,
+        "timeout": timeout,
+    }
+
+
+def _config_path() -> Path:
+    override = os.getenv("ROE_CONFIG_FILE")
+    if override:
+        return Path(override).expanduser()
+    config_home = os.getenv("XDG_CONFIG_HOME")
+    base = Path(config_home).expanduser() if config_home else Path.home() / ".config"
+    return base / "roe" / "config.json"
+
+
+def _load_cli_config() -> dict[str, Any]:
+    path = _config_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Roe config file is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Roe config file must contain a JSON object: {path}")
+    return data
+
+
+def _save_cli_config(data: dict[str, Any]) -> None:
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as out:
+        out.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def _prompt_secret(prompt: str) -> str:
+    if not sys.stdin.isatty():
+        raise ValueError("Missing API key and stdin is not interactive.")
+    value = getpass.getpass(prompt).strip()
+    if not value:
+        raise ValueError("API key is required.")
+    return value
+
+
+def _prompt_text(prompt: str) -> str:
+    if not sys.stdin.isatty():
+        raise ValueError("Missing organization ID and stdin is not interactive.")
+    value = input(prompt).strip()
+    if not value:
+        raise ValueError("Organization ID is required.")
+    return value
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _parse_float_env(name: str) -> float | None:
+    value = os.getenv(name)
+    return float(value) if value else None
+
+
+def _print_result(value: Any, *, as_json: bool) -> None:
+    payload = _to_jsonable(value)
+    if as_json:
+        print(json.dumps(payload, default=str, sort_keys=True))
+        return
+    if isinstance(payload, dict):
+        for key, item in payload.items():
+            print(f"{key}: {item}")
+    else:
+        print(payload)
+
+
+def _to_jsonable(value: Any) -> Any:
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    if isinstance(value, dict):
+        return {key: _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+def _print_error(exc: Exception) -> None:
+    if isinstance(exc, RoeAPIException):
+        prefix = (
+            f"Roe API error {exc.status_code}" if exc.status_code else "Roe API error"
+        )
+        print(f"{prefix}: {exc.message}", file=sys.stderr)
+        return
+    print(str(exc), file=sys.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -16,6 +16,7 @@ from roe.client import RoeClient
 from roe.exceptions import RoeAPIException
 
 DEFAULT_BASE_URL = "https://api.roe-ai.com"
+FAILED_TABLE_UPLOAD_STATUSES = frozenset({"FAILED", "EXPIRED"})
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -182,6 +183,9 @@ def _cmd_table_upload(args: argparse.Namespace) -> int:
     _print_result(result, as_json=args.json)
     if not args.json and result.get("status") == "IMPORTING":
         print(f"Status: roe table status {result['upload_id']} --json")
+    if result.get("status") in FAILED_TABLE_UPLOAD_STATUSES:
+        _print_terminal_failure("Table upload", result.get("error"))
+        return 1
     return 0
 
 
@@ -337,6 +341,11 @@ def _print_error(exc: Exception) -> None:
         print(f"{prefix}: {exc.message}", file=sys.stderr)
         return
     print(str(exc), file=sys.stderr)
+
+
+def _print_terminal_failure(label: str, error: Any) -> None:
+    message = str(error) if error else "reached a failed terminal status"
+    print(f"{label} failed: {message}", file=sys.stderr)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -8,6 +8,7 @@ import json
 import os
 import stat
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -263,13 +264,17 @@ def _load_cli_config() -> dict[str, Any]:
 def _save_cli_config(data: dict[str, Any]) -> None:
     path = _config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(
-        path,
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-        stat.S_IRUSR | stat.S_IWUSR,
-    )
-    with os.fdopen(fd, "w", encoding="utf-8") as out:
-        out.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as out:
+            out.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        os.chmod(temp_path, stat.S_IRUSR | stat.S_IWUSR)
+        os.replace(temp_path, path)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
 
 
 def _prompt_secret(prompt: str) -> str:

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -13,10 +13,10 @@ from pathlib import Path
 from typing import Any
 
 from roe.client import RoeClient
+from roe.api.table_upload_helpers import FAILED_UPLOAD_STATUSES
 from roe.exceptions import RoeAPIException
 
 DEFAULT_BASE_URL = "https://api.roe-ai.com"
-FAILED_TABLE_UPLOAD_STATUSES = frozenset({"FAILED", "EXPIRED"})
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -177,13 +177,14 @@ def _cmd_table_upload(args: argparse.Namespace) -> int:
             table_name=args.table_name,
             with_headers=args.with_headers,
             wait=args.wait,
-            poll_interval=args.poll_interval,
+            interval=args.poll_interval,
             timeout=args.upload_timeout,
         )
     _print_result(result, as_json=args.json)
-    if not args.json and result.get("status") == "IMPORTING":
-        print(f"Status: roe table status {result['upload_id']} --json")
-    if result.get("status") in FAILED_TABLE_UPLOAD_STATUSES:
+    upload_id = result.get("upload_id")
+    if not args.json and result.get("status") == "IMPORTING" and upload_id:
+        print(f"Status: roe table status {upload_id} --json")
+    if result.get("status") in FAILED_UPLOAD_STATUSES:
         _print_terminal_failure("Table upload", result.get("error"))
         return 1
     return 0

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
+import stat
 from http import HTTPStatus
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import httpx
+
+from roe import cli
 from roe._generated.models.table_upload_response import TableUploadResponse
 from roe._generated.types import UNSET, Response
 from roe.api.tables import TablesAPI
+from roe.client import RoeClient
 
 
 ORG_ID = "323e4567-e89b-12d3-a456-426614174002"
@@ -111,3 +117,251 @@ def test_tables_upload_via_roe_client_generated_registry():
             client.close()
 
     assert result.table_name == "events"
+
+
+def test_roe_client_sets_organization_headers_for_raw_table_helpers():
+    client = RoeClient(
+        api_key="test-key",
+        organization_id=ORG_ID,
+        base_url="https://example.invalid",
+    )
+    try:
+        headers = client.raw.get_httpx_client().headers
+        assert headers["X-Organization-Id"] == ORG_ID
+        assert headers["X-Roe-Organization-Id"] == ORG_ID
+    finally:
+        client.close()
+
+
+def test_tables_presigned_helpers_use_path_upload_id_endpoints():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/v1/tables/upload/presigned-url/":
+            return httpx.Response(
+                201,
+                json={
+                    "upload_id": "00000000-0000-0000-0000-000000000555",
+                    "upload_url": "https://uploads.example.com/customers.csv",
+                    "upload_method": "PUT",
+                    "headers": {"Content-Type": "text/csv"},
+                    "expires_at": "2026-06-05T00:00:00Z",
+                    "max_bytes": 2147483648,
+                },
+            )
+        if (
+            request.url.path
+            == "/v1/tables/upload/00000000-0000-0000-0000-000000000555/complete/"
+        ):
+            return httpx.Response(
+                202,
+                json={
+                    "upload_id": "00000000-0000-0000-0000-000000000555",
+                    "status": "IMPORTING",
+                    "table_name": "customers",
+                    "organization_id": ORG_ID,
+                    "summary": None,
+                },
+            )
+        if (
+            request.url.path
+            == "/v1/tables/upload/00000000-0000-0000-0000-000000000555/status/"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "upload_id": "00000000-0000-0000-0000-000000000555",
+                    "status": "COMPLETED",
+                    "table_name": "customers",
+                    "organization_id": ORG_ID,
+                    "summary": {"written_rows": 1},
+                },
+            )
+        return httpx.Response(404, json={"detail": "not found"})
+
+    httpx_client = httpx.Client(
+        base_url="http://backend",
+        transport=httpx.MockTransport(handler),
+    )
+    raw_client = MagicMock()
+    raw_client.get_httpx_client.return_value = httpx_client
+    api = TablesAPI(MagicMock(organization_id=ORG_ID), raw_client)
+
+    created = api.create_upload(
+        table_name="customers",
+        filename="customers.csv",
+        content_type="text/csv",
+        with_headers=False,
+    )
+    completed = api.complete_upload(upload_id=created["upload_id"])
+    status = api.upload_status(upload_id=created["upload_id"])
+
+    assert created["upload_method"] == "PUT"
+    assert completed["status"] == "IMPORTING"
+    assert status["status"] == "COMPLETED"
+    assert json.loads(requests[0].content) == {
+        "table_name": "customers",
+        "filename": "customers.csv",
+        "content_type": "text/csv",
+        "with_headers": False,
+        "organization_id": ORG_ID,
+    }
+    assert requests[1].method == "POST"
+    assert requests[1].content == b""
+    assert requests[2].method == "GET"
+    assert requests[2].content == b""
+
+
+def test_tables_upload_large_uses_presigned_storage_path(tmp_path):
+    path = tmp_path / "customers.csv"
+    path.write_text("name,age\nAda,37\n")
+    api = TablesAPI(MagicMock(organization_id=ORG_ID), MagicMock())
+    put_calls = []
+
+    with (
+        patch.object(
+            api,
+            "create_upload",
+            return_value={
+                "upload_id": "00000000-0000-0000-0000-000000000555",
+                "upload_url": "https://uploads.example.com/customers.csv",
+                "headers": {"Content-Type": "text/csv"},
+            },
+        ) as create_upload,
+        patch(
+            "roe.api.tables._put_presigned_upload",
+            side_effect=lambda **kwargs: put_calls.append(kwargs),
+        ) as put,
+        patch.object(
+            api,
+            "complete_upload",
+            return_value={
+                "upload_id": "00000000-0000-0000-0000-000000000555",
+                "status": "COMPLETED",
+                "table_name": "customers",
+            },
+        ) as complete_upload,
+    ):
+        result = api.upload_large(path, table_name="customers", with_headers=False)
+
+    create_upload.assert_called_once_with(
+        table_name="customers",
+        filename="customers.csv",
+        content_type="text/csv",
+        with_headers=False,
+        organization_id=None,
+    )
+    put.assert_called_once()
+    assert put_calls == [
+        {
+            "upload_url": "https://uploads.example.com/customers.csv",
+            "headers": {"Content-Type": "text/csv"},
+            "file_path": path,
+        }
+    ]
+    complete_upload.assert_called_once_with(
+        upload_id="00000000-0000-0000-0000-000000000555"
+    )
+    assert result["status"] == "COMPLETED"
+
+
+def test_cli_auth_login_writes_config(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+
+    result = cli.main(
+        [
+            "auth",
+            "login",
+            "--api-key",
+            "test-key",
+            "--organization-id",
+            ORG_ID,
+            "--base-url",
+            "http://backend",
+            "--timeout",
+            "12",
+        ]
+    )
+
+    assert result == 0
+    assert "Saved Roe credentials" in capsys.readouterr().out
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {
+        "api_key": "test-key",
+        "base_url": "http://backend",
+        "organization_id": ORG_ID,
+        "timeout": 12.0,
+    }
+
+
+def test_cli_table_upload_uses_large_upload_helper(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "api_key": "test-key",
+                "organization_id": ORG_ID,
+                "base_url": "http://backend",
+            }
+        ),
+        encoding="utf-8",
+    )
+    csv_path = tmp_path / "customers.csv"
+    csv_path.write_text("name,age\nAda,37\n", encoding="utf-8")
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+    calls = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append({"client": kwargs})
+            self.tables = SimpleNamespace(upload_large=self.upload_large)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def upload_large(self, *args, **kwargs):
+            calls.append({"upload_large": {"args": args, "kwargs": kwargs}})
+            return {
+                "upload_id": "00000000-0000-0000-0000-000000000555",
+                "status": "IMPORTING",
+                "table_name": "customers",
+            }
+
+    monkeypatch.setattr(cli, "RoeClient", FakeClient)
+
+    result = cli.main(
+        [
+            "table",
+            "upload",
+            str(csv_path),
+            "--table",
+            "customers",
+            "--no-headers",
+            "--wait",
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    assert calls[0] == {
+        "client": {
+            "api_key": "test-key",
+            "organization_id": ORG_ID,
+            "base_url": "http://backend",
+            "timeout": None,
+        }
+    }
+    assert calls[1]["upload_large"]["args"] == (str(csv_path),)
+    assert calls[1]["upload_large"]["kwargs"] == {
+        "table_name": "customers",
+        "with_headers": False,
+        "wait": True,
+        "poll_interval": 2.0,
+        "timeout": None,
+    }
+    assert json.loads(capsys.readouterr().out)["status"] == "IMPORTING"

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -358,26 +358,49 @@ def test_tables_upload_large_waits_for_import_when_requested(tmp_path):
             path,
             table_name="customers",
             wait=True,
-            poll_interval=0.5,
+            interval=0.5,
             timeout=30,
         )
 
     wait_for_upload.assert_called_once_with(
         upload_id="00000000-0000-0000-0000-000000000555",
-        poll_interval=0.5,
+        interval=0.5,
         timeout=30,
     )
     assert result["status"] == "COMPLETED"
 
 
-def test_tables_wait_for_upload_rejects_invalid_poll_interval():
+def test_tables_wait_for_upload_rejects_invalid_interval():
     api = TablesAPI(MagicMock(organization_id=ORG_ID), MagicMock())
 
-    with pytest.raises(ValueError, match="poll_interval"):
+    with pytest.raises(ValueError, match="interval"):
         api.wait_for_upload(
             upload_id="00000000-0000-0000-0000-000000000555",
-            poll_interval=0,
+            interval=0,
         )
+
+
+def test_tables_upload_large_validates_interval_before_uploading(tmp_path):
+    # A bad wait interval must fail before any bytes are uploaded or the
+    # import is started.
+    path = tmp_path / "customers.csv"
+    path.write_text("name,age\nAda,37\n")
+    api = TablesAPI(MagicMock(organization_id=ORG_ID), MagicMock())
+
+    with (
+        patch.object(api, "create_upload") as create_upload,
+        patch("roe.api.table_upload_helpers._put_presigned_upload") as put_upload,
+    ):
+        with pytest.raises(ValueError, match="interval"):
+            api.upload_large(
+                path,
+                table_name="customers",
+                wait=True,
+                interval=0,
+            )
+
+    create_upload.assert_not_called()
+    put_upload.assert_not_called()
 
 
 def test_tables_wait_for_upload_times_out():
@@ -387,7 +410,7 @@ def test_tables_wait_for_upload_times_out():
         with pytest.raises(TimeoutError, match="Timed out"):
             api.wait_for_upload(
                 upload_id="00000000-0000-0000-0000-000000000555",
-                poll_interval=0.01,
+                interval=0.01,
                 timeout=0,
             )
 
@@ -522,7 +545,7 @@ def test_cli_table_upload_uses_large_upload_helper(tmp_path, monkeypatch, capsys
         "table_name": "customers",
         "with_headers": False,
         "wait": True,
-        "poll_interval": 2.0,
+        "interval": 2.0,
         "timeout": None,
     }
     assert json.loads(capsys.readouterr().out)["status"] == "IMPORTING"

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -9,10 +9,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from roe import cli
 from roe._generated.models.table_upload_response import TableUploadResponse
 from roe._generated.types import UNSET, Response
+from roe.api import table_upload_helpers
 from roe.api.tables import TablesAPI
 from roe.client import RoeClient
 
@@ -213,6 +215,17 @@ def test_tables_presigned_helpers_use_path_upload_id_endpoints():
     assert requests[2].content == b""
 
 
+def test_tables_presigned_helpers_reject_invalid_upload_id_before_http():
+    raw_client = MagicMock()
+    raw_client.get_httpx_client.return_value = MagicMock()
+    api = TablesAPI(MagicMock(organization_id=ORG_ID), raw_client)
+
+    with pytest.raises(ValueError):
+        api.upload_status(upload_id="../not-a-uuid")
+
+    raw_client.get_httpx_client.return_value.request.assert_not_called()
+
+
 def test_tables_upload_large_uses_presigned_storage_path(tmp_path):
     path = tmp_path / "customers.csv"
     path.write_text("name,age\nAda,37\n")
@@ -230,7 +243,7 @@ def test_tables_upload_large_uses_presigned_storage_path(tmp_path):
             },
         ) as create_upload,
         patch(
-            "roe.api.tables._put_presigned_upload",
+            "roe.api.table_upload_helpers._put_presigned_upload",
             side_effect=lambda **kwargs: put_calls.append(kwargs),
         ) as put,
         patch.object(
@@ -266,6 +279,119 @@ def test_tables_upload_large_uses_presigned_storage_path(tmp_path):
     assert result["status"] == "COMPLETED"
 
 
+def test_put_presigned_upload_retries_and_does_not_forward_roe_auth_headers(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "customers.csv"
+    path.write_text("name,age\nAda,37\n")
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(503, json={"detail": "retry later"})
+        return httpx.Response(200)
+
+    real_client = httpx.Client
+
+    def fake_client(**kwargs):
+        assert kwargs["trust_env"] is False
+        return real_client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(table_upload_helpers.httpx, "Client", fake_client)
+    monkeypatch.setattr(table_upload_helpers.time, "sleep", lambda _: None)
+
+    table_upload_helpers._put_presigned_upload(
+        upload_url="https://uploads.example.com/customers.csv",
+        headers={
+            "Content-Type": "text/csv",
+            "Authorization": "Bearer roe-token",
+            "X-Organization-Id": ORG_ID,
+            "X-Roe-Organization-Id": ORG_ID,
+        },
+        file_path=path,
+    )
+
+    assert len(requests) == 2
+    assert requests[0].headers["content-type"] == "text/csv"
+    assert requests[0].headers["content-length"] == str(path.stat().st_size)
+    assert "authorization" not in requests[0].headers
+    assert "x-organization-id" not in requests[0].headers
+    assert "x-roe-organization-id" not in requests[0].headers
+
+
+def test_tables_upload_large_waits_for_import_when_requested(tmp_path):
+    path = tmp_path / "customers.csv"
+    path.write_text("name,age\nAda,37\n")
+    api = TablesAPI(MagicMock(organization_id=ORG_ID), MagicMock())
+
+    with (
+        patch.object(
+            api,
+            "create_upload",
+            return_value={
+                "upload_id": "00000000-0000-0000-0000-000000000555",
+                "upload_url": "https://uploads.example.com/customers.csv",
+                "headers": {},
+            },
+        ),
+        patch("roe.api.table_upload_helpers._put_presigned_upload"),
+        patch.object(
+            api,
+            "complete_upload",
+            return_value={
+                "upload_id": "00000000-0000-0000-0000-000000000555",
+                "status": "IMPORTING",
+            },
+        ),
+        patch.object(
+            api,
+            "wait_for_upload",
+            return_value={
+                "upload_id": "00000000-0000-0000-0000-000000000555",
+                "status": "COMPLETED",
+            },
+        ) as wait_for_upload,
+    ):
+        result = api.upload_large(
+            path,
+            table_name="customers",
+            wait=True,
+            poll_interval=0.5,
+            timeout=30,
+        )
+
+    wait_for_upload.assert_called_once_with(
+        upload_id="00000000-0000-0000-0000-000000000555",
+        poll_interval=0.5,
+        timeout=30,
+    )
+    assert result["status"] == "COMPLETED"
+
+
+def test_tables_wait_for_upload_rejects_invalid_poll_interval():
+    api = TablesAPI(MagicMock(organization_id=ORG_ID), MagicMock())
+
+    with pytest.raises(ValueError, match="poll_interval"):
+        api.wait_for_upload(
+            upload_id="00000000-0000-0000-0000-000000000555",
+            poll_interval=0,
+        )
+
+
+def test_tables_wait_for_upload_times_out():
+    api = TablesAPI(MagicMock(organization_id=ORG_ID), MagicMock())
+
+    with patch.object(api, "upload_status", return_value={"status": "IMPORTING"}):
+        with pytest.raises(TimeoutError, match="Timed out"):
+            api.wait_for_upload(
+                upload_id="00000000-0000-0000-0000-000000000555",
+                poll_interval=0.01,
+                timeout=0,
+            )
+
+
 def test_cli_auth_login_writes_config(tmp_path, monkeypatch, capsys):
     config_path = tmp_path / "config.json"
     monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
@@ -294,6 +420,41 @@ def test_cli_auth_login_writes_config(tmp_path, monkeypatch, capsys):
         "organization_id": ORG_ID,
         "timeout": 12.0,
     }
+
+
+def test_cli_auth_login_restricts_existing_config_permissions(
+    tmp_path, monkeypatch, capsys
+):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+    config_path.chmod(0o644)
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+
+    result = cli.main(
+        [
+            "auth",
+            "login",
+            "--api-key",
+            "test-key",
+            "--organization-id",
+            ORG_ID,
+        ]
+    )
+
+    assert result == 0
+    assert "Saved Roe credentials" in capsys.readouterr().out
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+
+def test_cli_table_upload_help_exposes_agent_friendly_command(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["table", "upload", "--help"])
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "roe table upload" in output
+    assert "--table" in output
+    assert "--wait" in output
 
 
 def test_cli_table_upload_uses_large_upload_helper(tmp_path, monkeypatch, capsys):
@@ -365,3 +526,51 @@ def test_cli_table_upload_uses_large_upload_helper(tmp_path, monkeypatch, capsys
         "timeout": None,
     }
     assert json.loads(capsys.readouterr().out)["status"] == "IMPORTING"
+
+
+def test_cli_table_status_routes_to_upload_status(monkeypatch, tmp_path, capsys):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "api_key": "test-key",
+                "organization_id": ORG_ID,
+                "base_url": "http://backend",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+    calls = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append({"client": kwargs})
+            self.tables = SimpleNamespace(upload_status=self.upload_status)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def upload_status(self, *, upload_id):
+            calls.append({"upload_status": upload_id})
+            return {"upload_id": upload_id, "status": "COMPLETED"}
+
+    monkeypatch.setattr(cli, "RoeClient", FakeClient)
+
+    result = cli.main(
+        [
+            "table",
+            "status",
+            "00000000-0000-0000-0000-000000000555",
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    assert calls[1] == {
+        "upload_status": "00000000-0000-0000-0000-000000000555"
+    }
+    assert json.loads(capsys.readouterr().out)["status"] == "COMPLETED"

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -528,6 +528,62 @@ def test_cli_table_upload_uses_large_upload_helper(tmp_path, monkeypatch, capsys
     assert json.loads(capsys.readouterr().out)["status"] == "IMPORTING"
 
 
+def test_cli_table_upload_wait_returns_nonzero_for_terminal_failure(
+    tmp_path, monkeypatch, capsys
+):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "api_key": "test-key",
+                "organization_id": ORG_ID,
+                "base_url": "http://backend",
+            }
+        ),
+        encoding="utf-8",
+    )
+    csv_path = tmp_path / "customers.csv"
+    csv_path.write_text("name,age\nAda,37\n", encoding="utf-8")
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.tables = SimpleNamespace(upload_large=self.upload_large)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def upload_large(self, *args, **kwargs):
+            return {
+                "upload_id": "00000000-0000-0000-0000-000000000555",
+                "status": "FAILED",
+                "table_name": "customers",
+                "error": "bad csv",
+            }
+
+    monkeypatch.setattr(cli, "RoeClient", FakeClient)
+
+    result = cli.main(
+        [
+            "table",
+            "upload",
+            str(csv_path),
+            "--table",
+            "customers",
+            "--wait",
+            "--json",
+        ]
+    )
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["status"] == "FAILED"
+    assert "Table upload failed: bad csv" in captured.err
+
+
 def test_cli_table_status_routes_to_upload_status(monkeypatch, tmp_path, capsys):
     config_path = tmp_path / "config.json"
     config_path.write_text(


### PR DESCRIPTION
## Summary

Adds the `roe` CLI inside the existing `roe-ai` Python package, sharing the same release cycle as the SDK.

- Adds `roe auth login`, `roe auth whoami`, `roe table upload`, and `roe table status`.
- Adds SDK helpers for the presigned table upload flow: `create_upload`, `complete_upload`, `upload_status`, `upload_large`, and `wait_for_upload`.
- Streams local CSV bytes directly to Roe storage through the presigned URL path.
- Adds organization headers to the SDK auth layer so raw helper endpoints that do not carry org id in the body still resolve the configured org.
- Documents the CLI commands in the README.

## Local deep review notes

- Reviewed CLI credential storage, config precedence, org header propagation, endpoint shapes, and local-file upload behavior.
- Fixed local-review issues before publishing: credential config files are now created with `0600` permissions from the start, and raw SDK helpers get organization headers.
- Kept the CLI intentionally scoped to auth and table upload/status rather than expanding it into a broad Roe admin surface.

## Validation

- `uv run pytest tests/unit` passed: 43 tests.
- `uv run ruff check src/roe/auth.py src/roe/cli.py src/roe/api/tables.py tests/unit/test_tables.py` passed.
- `git diff --check` passed.

## Companion PR

This is the roe-python companion to the roe-main table upload API/MCP draft PR. The CLI expects the presigned upload endpoints added there.