### PR TITLE
[codex] Add agent file upload CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ export ROE_API_KEY="your-api-key"
 export ROE_ORGANIZATION_ID="your-org-uuid"
 ```
 
+## Authentication: CLI vs Python SDK
+
+The CLI and Python SDK use the same Roe credentials: a Roe API key,
+organization ID, and optional API base URL.
+
+They do not share the same local config storage today:
+
+| Client | How it reads credentials |
+| --- | --- |
+| Python SDK | Constructor args or environment variables such as `ROE_API_KEY` and `ROE_ORGANIZATION_ID` |
+| Roe CLI | Command flags, environment variables, or the config file written by `roe auth login` |
+
+`roe auth login` saves credentials for CLI commands. It does not change Python
+SDK constructor args, and the Python SDK does not read the CLI config file.
+To use one set of credentials for both, set `ROE_API_KEY` and
+`ROE_ORGANIZATION_ID` in your shell.
+
+MCP OAuth sign-in is separate. It authenticates MCP clients such as ChatGPT,
+Claude, Claude Code, Codex, or Cursor. It does not log in the Roe CLI.
+
 ## Job Result Inspection
 
 After waiting for a job, inspect its outcome using the `JobStatus` enum.
@@ -149,10 +169,51 @@ upload = client.tables.upload(
 
 ## CLI
 
-The `roe-ai` package installs a small `roe` command for local workflows:
+The `roe-ai` package includes the `roe` command for local workflows.
+
+Run it without installing globally:
 
 ```bash
-roe auth login
+uvx --from roe-ai roe --help
+```
+
+Or install it once:
+
+```bash
+uv tool install roe-ai
+```
+
+You can also use `pipx install roe-ai` or `pip install roe-ai`.
+
+### Sign in
+
+Create a Roe API key in the Roe app, then save it for CLI commands:
+
+```bash
+roe auth login \
+  --api-key "your-api-key" \
+  --organization-id "your-org-uuid"
+```
+
+The hosted default is `https://api.roe-ai.com`. For a tenant deployment, use
+`https://api.<tenant>.roe-ai.com`:
+
+```bash
+roe auth login \
+  --api-key "your-api-key" \
+  --organization-id "your-org-uuid" \
+  --base-url "https://api.<tenant>.roe-ai.com"
+```
+
+Confirm the CLI can authenticate:
+
+```bash
+roe auth whoami --json
+```
+
+### Upload a table
+
+```bash
 roe table upload ./flights.csv --table flights --wait --json
 roe table status <upload_id> --json
 ```
@@ -160,6 +221,35 @@ roe table status <upload_id> --json
 Use `roe table upload` for large local CSVs. It creates a presigned upload
 session, streams file bytes directly to Roe storage, completes the import, and
 can poll until the table is ready.
+
+### Run an agent with local files
+
+Use the file input key from the agent version. PDF agents usually use
+`pdf_files`.
+
+```bash
+roe agent run "<agent_id>" \
+  --file pdf_files=./document.pdf \
+  --wait \
+  --json
+```
+
+For multiple PDFs, repeat `--file` with the same key:
+
+```bash
+roe agent run "<agent_id>" \
+  --file pdf_files=./first.pdf \
+  --file pdf_files=./second.pdf \
+  --wait \
+  --json
+```
+
+For async follow-up:
+
+```bash
+roe agent status "<job_id>" --json
+roe agent result "<job_id>" --json
+```
 
 ## Agent Examples
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A Python SDK for the [Roe](https://www.roe-ai.com/) API.
 
+> **v1.0.803** — Adds Roe CLI table uploads and agent local file inputs,
+> including multi-file agent runs via repeated `--file` flags. Use
+> `roe-ai>=1.0.803` for `roe table upload`, `roe table status`, and
+> `roe agent run --file`.
+>
 > **v1.0.802** — Version synchronization across the public SDKs: roe-ai
 > (Python), roe-typescript, and roe-golang. The public SDK packages now
 > share a single 1.0.x patch counter, driven by the SDK OpenAPI spec.
@@ -174,16 +179,17 @@ The `roe-ai` package includes the `roe` command for local workflows.
 Run it without installing globally:
 
 ```bash
-uvx --from roe-ai roe --help
+uvx --from "roe-ai>=1.0.803" roe --help
 ```
 
 Or install it once:
 
 ```bash
-uv tool install roe-ai
+uv tool install "roe-ai>=1.0.803"
 ```
 
-You can also use `pipx install roe-ai` or `pip install roe-ai`.
+You can also use `pipx install "roe-ai>=1.0.803"` or
+`pip install "roe-ai>=1.0.803"`.
 
 ### Sign in
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,16 @@ Confirm the CLI can authenticate:
 roe auth whoami --json
 ```
 
+### Choose the upload path
+
+| Input | Use |
+| --- | --- |
+| Local CSV that should become a queryable Roe table | `roe table upload ./flights.csv --table flights --wait --json` |
+| Small CSV bytes in Python | `client.tables.upload(...)` |
+| Local PDF, DOCX, image, or other agent file input | `roe agent run "<agent_id>" --file key=./file.pdf --wait --json` or `FileUpload(path="file.pdf")` |
+| PDF/document URL or existing Roe file ID | CLI `--input key=value` or SDK string input |
+| In-memory PDF/document bytes in Python | `FileUpload.from_bytes(data, filename="file.pdf", mime_type="application/pdf")` |
+
 ### Upload a table
 
 ```bash
@@ -222,10 +232,13 @@ Use `roe table upload` for large local CSVs. It creates a presigned upload
 session, streams file bytes directly to Roe storage, completes the import, and
 can poll until the table is ready.
 
+Table upload is only for CSV data that should become a queryable Roe table.
+Use agent file inputs for PDFs, DOCX files, images, and other documents.
+
 ### Run an agent with local files
 
 Use the file input key from the agent version. PDF agents usually use
-`pdf_files`.
+`pdf_files`. Document agents may use keys such as `documents` or `pdf_file`.
 
 ```bash
 roe agent run "<agent_id>" \
@@ -240,6 +253,24 @@ For multiple PDFs, repeat `--file` with the same key:
 roe agent run "<agent_id>" \
   --file pdf_files=./first.pdf \
   --file pdf_files=./second.pdf \
+  --wait \
+  --json
+```
+
+For DOCX or other local document files, use the agent's file input key:
+
+```bash
+roe agent run "<agent_id>" \
+  --file documents=./contract.docx \
+  --wait \
+  --json
+```
+
+For a PDF URL or an existing Roe file ID, pass the value as a scalar input:
+
+```bash
+roe agent run "<agent_id>" \
+  --input pdf_file=https://example.com/policy.pdf \
   --wait \
   --json
 ```
@@ -291,6 +322,8 @@ result = job.wait()
 Extract structured information from PDFs:
 
 ```python
+from roe import FileUpload
+
 agent = client.agents.create(
     name="Resume Parser",
     engine_class_id="PDFExtractionEngine",
@@ -312,8 +345,35 @@ agent = client.agents.create(
     }
 )
 
-job = client.agents.run(agent_id=str(agent.id), pdf_files="resume.pdf")
+# Local path: uploaded as multipart file bytes.
+job = client.agents.run(
+    agent_id=str(agent.id),
+    pdf_files=FileUpload(path="resume.pdf"),
+)
 result = job.wait()
+```
+
+PDF inputs can also be URLs, existing Roe file IDs, or in-memory bytes:
+
+```python
+job_from_url = client.agents.run(
+    agent_id="agent-uuid",
+    pdf_files="https://example.com/resume.pdf",
+)
+
+job_from_file_id = client.agents.run(
+    agent_id="agent-uuid",
+    pdf_files="00000000-0000-0000-0000-000000000999",
+)
+
+job_from_bytes = client.agents.run(
+    agent_id="agent-uuid",
+    pdf_files=FileUpload.from_bytes(
+        pdf_bytes,
+        filename="resume.pdf",
+        mime_type="application/pdf",
+    ),
+)
 ```
 
 ### Web Insights

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from roe.client import RoeClient
 from roe.exceptions import RoeAPIException
+from roe.models import FileUpload
 
 DEFAULT_BASE_URL = "https://api.roe-ai.com"
 FAILED_TABLE_UPLOAD_STATUSES = frozenset({"FAILED", "EXPIRED"})
@@ -56,6 +57,87 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_connection_options(whoami)
     whoami.add_argument("--json", action="store_true", help="Print JSON output.")
     whoami.set_defaults(func=_cmd_auth_whoami)
+
+    agent = subparsers.add_parser("agent", help="Run Roe agents.")
+    agent_subparsers = agent.add_subparsers(dest="agent_command", required=True)
+
+    run = agent_subparsers.add_parser(
+        "run",
+        help="Run an agent with text and local file inputs.",
+        description=(
+            "Run a Roe agent. Use --file pdf_files=./document.pdf for PDF inputs; "
+            "repeat --file with the same key for multi-file inputs."
+        ),
+    )
+    _add_connection_options(run)
+    run.add_argument("agent_id", help="Agent UUID.")
+    run.add_argument(
+        "--version",
+        dest="version_id",
+        help="Optional agent version UUID. Defaults to the current version.",
+    )
+    run.add_argument(
+        "--input",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Text/scalar agent input. Repeat for multiple input keys.",
+    )
+    run.add_argument(
+        "--file",
+        action="append",
+        default=[],
+        metavar="KEY=PATH",
+        help=(
+            "Local file input, for example pdf_files=./document.pdf. "
+            "Repeat with the same key for agents that accept multiple files."
+        ),
+    )
+    run.add_argument(
+        "--metadata",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Job metadata key/value. Repeat for multiple metadata fields.",
+    )
+    run.add_argument(
+        "--metadata-json",
+        help="Job metadata as a JSON object. Merged before --metadata values.",
+    )
+    run.add_argument("--idempotency-key", help="Optional idempotency key.")
+    run.add_argument("--wait", action="store_true", help="Poll until the job finishes.")
+    run.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5.0,
+        help="Seconds between job status checks when --wait is used.",
+    )
+    run.add_argument(
+        "--job-timeout",
+        type=float,
+        default=None,
+        help="Maximum seconds to wait for job completion.",
+    )
+    run.add_argument("--json", action="store_true", help="Print JSON output.")
+    run.set_defaults(func=_cmd_agent_run)
+
+    agent_status = agent_subparsers.add_parser(
+        "status",
+        help="Show an agent job status.",
+    )
+    _add_connection_options(agent_status)
+    agent_status.add_argument("job_id", help="Agent job UUID.")
+    agent_status.add_argument("--json", action="store_true", help="Print JSON output.")
+    agent_status.set_defaults(func=_cmd_agent_status)
+
+    agent_result = agent_subparsers.add_parser(
+        "result",
+        help="Show an agent job result.",
+    )
+    _add_connection_options(agent_result)
+    agent_result.add_argument("job_id", help="Agent job UUID.")
+    agent_result.add_argument("--json", action="store_true", help="Print JSON output.")
+    agent_result.set_defaults(func=_cmd_agent_result)
 
     table = subparsers.add_parser("table", help="Manage Roe tables.")
     table_subparsers = table.add_subparsers(dest="table_command", required=True)
@@ -166,6 +248,52 @@ def _cmd_auth_login(args: argparse.Namespace) -> int:
 def _cmd_auth_whoami(args: argparse.Namespace) -> int:
     with _new_client(args) as client:
         result = client.users.me()
+    _print_result(result, as_json=args.json)
+    return 0
+
+
+def _cmd_agent_run(args: argparse.Namespace) -> int:
+    inputs = _parse_agent_inputs(args.input, args.file)
+    metadata = _parse_metadata(args.metadata_json, args.metadata)
+    with _new_client(args) as client:
+        if args.version_id:
+            job = client.agents.run_version(
+                args.agent_id,
+                args.version_id,
+                metadata=metadata,
+                idempotency_key=args.idempotency_key,
+                **inputs,
+            )
+        else:
+            job = client.agents.run(
+                args.agent_id,
+                metadata=metadata,
+                idempotency_key=args.idempotency_key,
+                **inputs,
+            )
+        result = (
+            job.wait(interval=args.poll_interval, timeout=args.job_timeout)
+            if args.wait
+            else {"job_id": job.id}
+        )
+
+    _print_result(result, as_json=args.json)
+    if not args.json and not args.wait:
+        print(f"Status: roe agent status {job.id} --json")
+        print(f"Result: roe agent result {job.id} --json")
+    return 0
+
+
+def _cmd_agent_status(args: argparse.Namespace) -> int:
+    with _new_client(args) as client:
+        result = client.agents.jobs.retrieve_status(args.job_id)
+    _print_result(result, as_json=args.json)
+    return 0
+
+
+def _cmd_agent_result(args: argparse.Namespace) -> int:
+    with _new_client(args) as client:
+        result = client.agents.jobs.retrieve_result(args.job_id)
     _print_result(result, as_json=args.json)
     return 0
 
@@ -309,6 +437,63 @@ def _first_present(*values: Any) -> Any:
 def _parse_float_env(name: str) -> float | None:
     value = os.getenv(name)
     return float(value) if value else None
+
+
+def _parse_agent_inputs(
+    raw_inputs: list[str],
+    raw_files: list[str],
+) -> dict[str, Any]:
+    parsed: dict[str, Any] = {}
+    for item in raw_inputs:
+        key, value = _parse_key_value(item, option="--input")
+        if key in parsed:
+            raise ValueError(f"Duplicate agent input key: {key}")
+        parsed[key] = value
+
+    grouped_files: dict[str, list[FileUpload]] = {}
+    for item in raw_files:
+        key, value = _parse_key_value(item, option="--file")
+        if key in parsed:
+            raise ValueError(
+                f"Agent input key {key!r} cannot be both --input and --file"
+            )
+        path = Path(value).expanduser()
+        if not path.is_file():
+            raise FileNotFoundError(f"Agent input file not found: {path}")
+        grouped_files.setdefault(key, []).append(FileUpload(path=str(path)))
+
+    for key, files in grouped_files.items():
+        parsed[key] = files[0] if len(files) == 1 else files
+    return parsed
+
+
+def _parse_metadata(
+    metadata_json: str | None,
+    raw_metadata: list[str],
+) -> dict[str, Any] | None:
+    metadata: dict[str, Any] = {}
+    if metadata_json:
+        try:
+            parsed = json.loads(metadata_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError("--metadata-json must be valid JSON.") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("--metadata-json must be a JSON object.")
+        metadata.update(parsed)
+    for item in raw_metadata:
+        key, value = _parse_key_value(item, option="--metadata")
+        metadata[key] = value
+    return metadata or None
+
+
+def _parse_key_value(value: str, *, option: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise ValueError(f"{option} must be in KEY=VALUE form.")
+    key, item = value.split("=", 1)
+    key = key.strip()
+    if not key:
+        raise ValueError(f"{option} key is required.")
+    return key, item
 
 
 def _print_result(value: Any, *, as_json: bool) -> None:

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -65,8 +65,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "run",
         help="Run an agent with text and local file inputs.",
         description=(
-            "Run a Roe agent. Use --file pdf_files=./document.pdf for PDF inputs; "
-            "repeat --file with the same key for multi-file inputs."
+            "Run a Roe agent. Use --file pdf_files=./document.pdf or "
+            "--file documents=./contract.docx for local file inputs; repeat "
+            "--file with the same key for multi-file inputs. Use --input for "
+            "URLs and existing Roe file IDs."
         ),
     )
     _add_connection_options(run)
@@ -81,7 +83,10 @@ def _build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         metavar="KEY=VALUE",
-        help="Text/scalar agent input. Repeat for multiple input keys.",
+        help=(
+            "Text/scalar agent input, including URLs and existing Roe file IDs. "
+            "Repeat for multiple input keys."
+        ),
     )
     run.add_argument(
         "--file",
@@ -89,7 +94,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
         metavar="KEY=PATH",
         help=(
-            "Local file input, for example pdf_files=./document.pdf. "
+            "Local file input, for example pdf_files=./document.pdf or "
+            "documents=./contract.docx. "
             "Repeat with the same key for agents that accept multiple files."
         ),
     )

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -9,6 +9,7 @@ import os
 import stat
 import sys
 import tempfile
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,7 @@ from roe.models import FileUpload
 
 DEFAULT_BASE_URL = "https://api.roe-ai.com"
 FAILED_TABLE_UPLOAD_STATUSES = frozenset({"FAILED", "EXPIRED"})
+MIN_UPLOAD_CLI_VERSION = "1.0.803"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -36,7 +38,15 @@ def main(argv: list[str] | None = None) -> int:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="roe",
-        description="Roe AI command-line tools.",
+        description=(
+            "Roe AI command-line tools. Table uploads and agent local file uploads "
+            f"require roe-ai>={MIN_UPLOAD_CLI_VERSION}."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"roe-ai {_package_version()}",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -537,6 +547,13 @@ def _print_error(exc: Exception) -> None:
 def _print_terminal_failure(label: str, error: Any) -> None:
     message = str(error) if error else "reached a failed terminal status"
     print(f"{label} failed: {message}", file=sys.stderr)
+
+
+def _package_version() -> str:
+    try:
+        return version("roe-ai")
+    except PackageNotFoundError:  # pragma: no cover - editable source tree fallback
+        return "0.0.0"
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -15,9 +15,10 @@ from typing import Any
 
 from roe.client import RoeClient
 from roe.exceptions import RoeAPIException
-from roe.models import FileUpload
+from roe.models import FileUpload, JobStatus
 
 DEFAULT_BASE_URL = "https://api.roe-ai.com"
+FAILED_AGENT_JOB_STATUSES = frozenset({JobStatus.FAILURE, JobStatus.CANCELLED})
 FAILED_TABLE_UPLOAD_STATUSES = frozenset({"FAILED", "EXPIRED"})
 MIN_UPLOAD_CLI_VERSION = "1.0.803"
 
@@ -297,6 +298,9 @@ def _cmd_agent_run(args: argparse.Namespace) -> int:
     if not args.json and not args.wait:
         print(f"Status: roe agent status {job.id} --json")
         print(f"Result: roe agent result {job.id} --json")
+    if args.wait and _payload_value(result, "status") in FAILED_AGENT_JOB_STATUSES:
+        _print_terminal_failure("Agent job", _payload_error(result))
+        return 1
     return 0
 
 
@@ -532,6 +536,20 @@ def _to_jsonable(value: Any) -> Any:
     if isinstance(value, list):
         return [_to_jsonable(item) for item in value]
     return value
+
+
+def _payload_value(value: Any, key: str) -> Any:
+    payload = _to_jsonable(value)
+    if not isinstance(payload, dict):
+        return None
+    item = payload.get(key)
+    if key == "status" and item is not None:
+        return int(item)
+    return item
+
+
+def _payload_error(value: Any) -> Any:
+    return _payload_value(value, "error_message") or _payload_value(value, "error")
 
 
 def _print_error(exc: Exception) -> None:

--- a/src/roe/models/file.py
+++ b/src/roe/models/file.py
@@ -1,8 +1,9 @@
 """File upload helper model."""
 
+import io
 import mimetypes
 import os
-from typing import BinaryIO
+from typing import BinaryIO, cast
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -11,7 +12,9 @@ class FileUpload(BaseModel):
     """Helper class for explicit file uploads with metadata."""
 
     path: str | None = Field(default=None, description="File path to upload")
-    file_obj: BinaryIO | None = Field(default=None, description="File object to upload")
+    file_obj: io.IOBase | None = Field(
+        default=None, description="File object to upload"
+    )
     filename: str | None = Field(default=None, description="Override filename")
     mime_type: str | None = Field(
         default=None, description="MIME type (auto-detected if not provided)"
@@ -19,6 +22,23 @@ class FileUpload(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+    @classmethod
+    def from_bytes(
+        cls,
+        data: bytes | bytearray | memoryview,
+        *,
+        filename: str,
+        mime_type: str | None = None,
+    ) -> "FileUpload":
+        """Create an upload from in-memory bytes with explicit file metadata."""
+        if not filename:
+            raise ValueError("filename is required for byte uploads")
+        return cls(
+            file_obj=io.BytesIO(bytes(data)),
+            filename=filename,
+            mime_type=mime_type,
+        )
 
     @model_validator(mode="after")
     def validate_file_source(self):
@@ -61,7 +81,7 @@ class FileUpload(BaseModel):
     def open(self) -> BinaryIO:
         """Open the file for reading."""
         if self.file_obj:
-            return self.file_obj
+            return cast(BinaryIO, self.file_obj)
 
         if self.path:
             return open(self.path, "rb")

--- a/src/roe/utils/_dynamic_call.py
+++ b/src/roe/utils/_dynamic_call.py
@@ -34,7 +34,7 @@ def call_dynamic(
 
     Calls `ep_module._get_kwargs(...)` to build the URL, query string and auth,
     then strips the generated body and replaces it with our own multipart
-    payload built from `build_execution_multipart`. Raises a typed
+    payload built from `build_execution_multipart_payload`. Raises a typed
     `RoeAPIException` on non-2xx via `translate_response`.
     """
     multipart = build_execution_multipart_payload(inputs, metadata)

--- a/src/roe/utils/_dynamic_call.py
+++ b/src/roe/utils/_dynamic_call.py
@@ -17,7 +17,7 @@ import httpx
 
 from roe._generated.client import AuthenticatedClient
 from roe.exceptions import translate_response
-from roe.utils.inputs import build_execution_multipart
+from roe.utils.inputs import build_execution_multipart_payload
 
 
 def call_dynamic(
@@ -37,13 +37,13 @@ def call_dynamic(
     payload built from `build_execution_multipart`. Raises a typed
     `RoeAPIException` on non-2xx via `translate_response`.
     """
-    data, files = build_execution_multipart(inputs, metadata)
+    multipart = build_execution_multipart_payload(inputs, metadata)
     kwargs = ep_module._get_kwargs(organization_id=organization_id, **path_params)
     kwargs.pop("json", None)
     kwargs.pop("data", None)
     kwargs.pop("files", None)
-    kwargs["data"] = data
-    kwargs["files"] = files
+    kwargs["data"] = multipart.data
+    kwargs["files"] = multipart.files
     request_headers = kwargs.setdefault("headers", {})
     request_headers["x-roe-skip-retry"] = (
         "1"  # multipart POST — do not replay (aligns with TS)
@@ -51,6 +51,9 @@ def call_dynamic(
     if extra_headers is not None:
         request_headers.update(extra_headers)
     request_headers.pop("Content-Type", None)  # let httpx pick the boundary
-    response = raw.get_httpx_client().request(**kwargs)
-    translate_response(response)
-    return response
+    try:
+        response = raw.get_httpx_client().request(**kwargs)
+        translate_response(response)
+        return response
+    finally:
+        multipart.close()

--- a/src/roe/utils/inputs.py
+++ b/src/roe/utils/inputs.py
@@ -39,27 +39,6 @@ class ExecutionMultipart:
             file_obj.close()
 
 
-def build_execution_multipart(
-    inputs: dict[str, Any],
-    metadata: dict[str, Any] | None = None,
-) -> tuple[dict[str, Any], list[tuple[str, Any]]]:
-    """Split caller-owned inputs into ``(form_data, files)`` for multipart.
-
-    Use ``build_execution_multipart_payload`` for local paths or ``FileUpload``
-    path values because it returns a payload object that can close SDK-opened
-    file handles after the request.
-    """
-    multipart = build_execution_multipart_payload(inputs, metadata)
-    if multipart.closeables:
-        multipart.close()
-        raise ValueError(
-            "build_execution_multipart cannot safely return SDK-opened file "
-            "handles. Use build_execution_multipart_payload(...) and call "
-            "payload.close() after the request."
-        )
-    return multipart.data, multipart.files
-
-
 def build_execution_multipart_payload(
     inputs: dict[str, Any],
     metadata: dict[str, Any] | None = None,

--- a/src/roe/utils/inputs.py
+++ b/src/roe/utils/inputs.py
@@ -17,35 +17,59 @@ Bypasses the generated request models' ``to_multipart()`` because
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 import io
 import json as _json
 import mimetypes
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 from roe.models.file import FileUpload
 from roe.utils.file_detection import is_file_path, is_uuid_string
 
 
+@dataclass
+class ExecutionMultipart:
+    data: dict[str, Any]
+    files: list[tuple[str, Any]]
+    closeables: list[BinaryIO] = field(default_factory=list)
+
+    def close(self) -> None:
+        for file_obj in self.closeables:
+            file_obj.close()
+
+
 def build_execution_multipart(
     inputs: dict[str, Any],
     metadata: dict[str, Any] | None = None,
-) -> tuple[dict[str, Any], dict[str, Any]]:
+) -> tuple[dict[str, Any], list[tuple[str, Any]]]:
     """Split inputs into ``(form_data, files)`` for an httpx multipart request.
 
     Detects ``FileUpload``, file-like objects, file-path strings, UUID strings
     (treated as Roe file references — kept in form data, not opened), and
     plain scalars. ``metadata`` is JSON-encoded into the form when present.
     """
+    multipart = build_execution_multipart_payload(inputs, metadata)
+    return multipart.data, multipart.files
+
+
+def build_execution_multipart_payload(
+    inputs: dict[str, Any],
+    metadata: dict[str, Any] | None = None,
+) -> ExecutionMultipart:
+    """Build a multipart payload and track SDK-opened file objects."""
     form_data: dict[str, Any] = {}
-    files: dict[str, Any] = {}
+    files: list[tuple[str, Any]] = []
+    closeables: list[BinaryIO] = []
 
     for key, value in inputs.items():
         if isinstance(value, FileUpload):
-            filename, file_obj, mime_type = value.to_multipart_tuple()
-            files[key] = (filename, file_obj, mime_type)
+            _append_file(files, closeables, key, value)
+        elif _is_file_sequence(value):
+            for item in value:
+                _append_file(files, closeables, key, item)
         elif isinstance(value, (io.IOBase, io.BytesIO)) or hasattr(value, "read"):
-            files[key] = value
+            files.append((key, value))
         elif isinstance(value, str):
             if is_uuid_string(value):
                 form_data[key] = value
@@ -53,7 +77,9 @@ def build_execution_multipart(
                 p = Path(value)
                 mime, _ = mimetypes.guess_type(p.name)
                 with open(value, "rb") as fh:
-                    files[key] = (p.name, fh.read(), mime or "application/octet-stream")
+                    files.append(
+                        (key, (p.name, fh.read(), mime or "application/octet-stream"))
+                    )
             else:
                 form_data[key] = value
         else:
@@ -63,4 +89,33 @@ def build_execution_multipart(
     if metadata is not None:
         form_data["metadata"] = _json.dumps(metadata)
 
-    return form_data, files
+    return ExecutionMultipart(data=form_data, files=files, closeables=closeables)
+
+
+def _is_file_sequence(value: Any) -> bool:
+    if not isinstance(value, (list, tuple)):
+        return False
+    return bool(value) and all(_is_file_value(item) for item in value)
+
+
+def _is_file_value(value: Any) -> bool:
+    return (
+        isinstance(value, FileUpload)
+        or isinstance(value, (io.IOBase, io.BytesIO))
+        or hasattr(value, "read")
+    )
+
+
+def _append_file(
+    files: list[tuple[str, Any]],
+    closeables: list[BinaryIO],
+    key: str,
+    value: Any,
+) -> None:
+    if isinstance(value, FileUpload):
+        filename, file_obj, mime_type = value.to_multipart_tuple()
+        files.append((key, (filename, file_obj, mime_type)))
+        if value.path is not None:
+            closeables.append(file_obj)
+        return
+    files.append((key, value))

--- a/src/roe/utils/inputs.py
+++ b/src/roe/utils/inputs.py
@@ -6,7 +6,7 @@ for ``httpx``'s ``data=`` and ``files=`` kwargs. Detects:
   * ``FileUpload`` instances → ``files``
   * file-like objects (``io.IOBase``, anything with ``.read()``) → ``files``
   * UUID strings → ``form_data`` (Roe file ID reference, never opened)
-  * existing file paths → ``files`` (auto-opened in binary mode)
+  * existing file paths → ``files`` (auto-opened in binary mode and streamed)
   * everything else → stringified into ``form_data``
 
 Bypasses the generated request models' ``to_multipart()`` because
@@ -62,32 +62,44 @@ def build_execution_multipart_payload(
     files: list[tuple[str, Any]] = []
     closeables: list[BinaryIO] = []
 
-    for key, value in inputs.items():
-        if isinstance(value, FileUpload):
-            _append_file(files, closeables, key, value)
-        elif _is_file_sequence(value):
-            for item in value:
-                _append_file(files, closeables, key, item)
-        elif isinstance(value, (io.IOBase, io.BytesIO)) or hasattr(value, "read"):
-            files.append((key, value))
-        elif isinstance(value, str):
-            if is_uuid_string(value):
-                form_data[key] = value
-            elif is_file_path(value):
-                p = Path(value)
-                mime, _ = mimetypes.guess_type(p.name)
-                with open(value, "rb") as fh:
-                    files.append(
-                        (key, (p.name, fh.read(), mime or "application/octet-stream"))
-                    )
+    try:
+        for key, value in inputs.items():
+            if isinstance(value, FileUpload):
+                _append_file(files, closeables, key, value)
+            elif _is_file_sequence(value):
+                for item in value:
+                    _append_file(files, closeables, key, item)
+            elif _is_ambiguous_file_sequence(value):
+                raise ValueError(
+                    f"Agent input {key!r} mixes local file uploads with scalar "
+                    "values. Use FileUpload/local paths for files, and pass URLs "
+                    "or Roe file IDs as scalar inputs."
+                )
+            elif _is_raw_bytes(value):
+                raise ValueError(
+                    f"Agent input {key!r} is raw bytes. Use "
+                    "FileUpload.from_bytes(..., filename=...) so Roe receives a "
+                    "filename and MIME type."
+                )
+            elif isinstance(value, (io.IOBase, io.BytesIO)) or hasattr(value, "read"):
+                files.append((key, value))
+            elif isinstance(value, str):
+                if is_uuid_string(value):
+                    form_data[key] = value
+                elif is_file_path(value):
+                    _append_path_file(files, closeables, key, value)
+                else:
+                    form_data[key] = value
             else:
-                form_data[key] = value
-        else:
-            if value is not None:
-                form_data[key] = str(value)
+                if value is not None:
+                    form_data[key] = str(value)
 
-    if metadata is not None:
-        form_data["metadata"] = _json.dumps(metadata)
+        if metadata is not None:
+            form_data["metadata"] = _json.dumps(metadata)
+    except Exception:
+        for file_obj in closeables:
+            file_obj.close()
+        raise
 
     return ExecutionMultipart(data=form_data, files=files, closeables=closeables)
 
@@ -95,7 +107,20 @@ def build_execution_multipart_payload(
 def _is_file_sequence(value: Any) -> bool:
     if not isinstance(value, (list, tuple)):
         return False
-    return bool(value) and all(_is_file_value(item) for item in value)
+    return bool(value) and all(
+        _is_file_value(item) or _is_file_path_string(item) for item in value
+    )
+
+
+def _is_ambiguous_file_sequence(value: Any) -> bool:
+    if not isinstance(value, (list, tuple)):
+        return False
+    if any(_is_raw_bytes(item) for item in value):
+        return True
+    has_file = any(_is_file_value(item) or _is_file_path_string(item) for item in value)
+    return has_file and not all(
+        _is_file_value(item) or _is_file_path_string(item) for item in value
+    )
 
 
 def _is_file_value(value: Any) -> bool:
@@ -104,6 +129,14 @@ def _is_file_value(value: Any) -> bool:
         or isinstance(value, (io.IOBase, io.BytesIO))
         or hasattr(value, "read")
     )
+
+
+def _is_file_path_string(value: Any) -> bool:
+    return isinstance(value, str) and is_file_path(value)
+
+
+def _is_raw_bytes(value: Any) -> bool:
+    return isinstance(value, (bytes, bytearray, memoryview))
 
 
 def _append_file(
@@ -118,4 +151,20 @@ def _append_file(
         if value.path is not None:
             closeables.append(file_obj)
         return
+    if _is_file_path_string(value):
+        _append_path_file(files, closeables, key, value)
+        return
     files.append((key, value))
+
+
+def _append_path_file(
+    files: list[tuple[str, Any]],
+    closeables: list[BinaryIO],
+    key: str,
+    path: str,
+) -> None:
+    p = Path(path)
+    mime, _ = mimetypes.guess_type(p.name)
+    file_obj = open(path, "rb")
+    files.append((key, (p.name, file_obj, mime or "application/octet-stream")))
+    closeables.append(file_obj)

--- a/src/roe/utils/inputs.py
+++ b/src/roe/utils/inputs.py
@@ -43,13 +43,20 @@ def build_execution_multipart(
     inputs: dict[str, Any],
     metadata: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], list[tuple[str, Any]]]:
-    """Split inputs into ``(form_data, files)`` for an httpx multipart request.
+    """Split caller-owned inputs into ``(form_data, files)`` for multipart.
 
-    Detects ``FileUpload``, file-like objects, file-path strings, UUID strings
-    (treated as Roe file references — kept in form data, not opened), and
-    plain scalars. ``metadata`` is JSON-encoded into the form when present.
+    Use ``build_execution_multipart_payload`` for local paths or ``FileUpload``
+    path values because it returns a payload object that can close SDK-opened
+    file handles after the request.
     """
     multipart = build_execution_multipart_payload(inputs, metadata)
+    if multipart.closeables:
+        multipart.close()
+        raise ValueError(
+            "build_execution_multipart cannot safely return SDK-opened file "
+            "handles. Use build_execution_multipart_payload(...) and call "
+            "payload.close() after the request."
+        )
     return multipart.data, multipart.files
 
 

--- a/tests/unit/test_agents_wrapper_transport.py
+++ b/tests/unit/test_agents_wrapper_transport.py
@@ -11,6 +11,7 @@ import pytest
 from roe.api.agents import AgentsAPI
 from roe.exceptions import NotFoundError
 from roe.models import FileUpload
+from roe.utils.inputs import build_execution_multipart
 
 ORG_ID = "00000000-0000-0000-0000-000000000123"
 AGENT_ID = "00000000-0000-0000-0000-000000000111"
@@ -133,6 +134,14 @@ def test_run_streams_existing_string_path_instead_of_reading_into_memory(tmp_pat
     assert part[1].name == str(document)
     assert part[1].closed
     assert part[2] == "application/pdf"
+
+
+def test_legacy_multipart_wrapper_rejects_sdk_opened_local_files(tmp_path):
+    document = tmp_path / "policy.pdf"
+    document.write_bytes(b"%PDF-1.4\nlocal path\n")
+
+    with pytest.raises(ValueError, match="build_execution_multipart_payload"):
+        build_execution_multipart({"pdf_file": str(document)})
 
 
 def test_run_sends_path_string_list_as_repeated_file_fields(tmp_path):

--- a/tests/unit/test_agents_wrapper_transport.py
+++ b/tests/unit/test_agents_wrapper_transport.py
@@ -10,6 +10,7 @@ import pytest
 
 from roe.api.agents import AgentsAPI
 from roe.exceptions import NotFoundError
+from roe.models import FileUpload
 
 ORG_ID = "00000000-0000-0000-0000-000000000123"
 AGENT_ID = "00000000-0000-0000-0000-000000000111"
@@ -54,3 +55,27 @@ def test_run_passes_idempotency_key_through_dynamic_wrapper():
     assert kwargs["headers"]["Idempotency-Key"] == "idem-123"
     assert kwargs["headers"]["x-roe-skip-retry"] == "1"
     assert job.id == JOB_ID
+
+
+def test_run_sends_repeated_file_fields_for_multiple_pdf_inputs(tmp_path):
+    first = tmp_path / "first.pdf"
+    second = tmp_path / "second.pdf"
+    first.write_bytes(b"%PDF-1.4\nfirst\n")
+    second.write_bytes(b"%PDF-1.4\nsecond\n")
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run(
+        AGENT_ID,
+        prompt="summarize",
+        pdf_files=[
+            FileUpload(path=str(first)),
+            FileUpload(path=str(second)),
+        ],
+    )
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["data"] == {"prompt": "summarize"}
+    pdf_parts = [part for key, part in kwargs["files"] if key == "pdf_files"]
+    assert [part[0] for part in pdf_parts] == ["first.pdf", "second.pdf"]
+    assert [part[2] for part in pdf_parts] == ["application/pdf", "application/pdf"]
+    assert all(part[1].closed for part in pdf_parts)

--- a/tests/unit/test_agents_wrapper_transport.py
+++ b/tests/unit/test_agents_wrapper_transport.py
@@ -79,3 +79,107 @@ def test_run_sends_repeated_file_fields_for_multiple_pdf_inputs(tmp_path):
     assert [part[0] for part in pdf_parts] == ["first.pdf", "second.pdf"]
     assert [part[2] for part in pdf_parts] == ["application/pdf", "application/pdf"]
     assert all(part[1].closed for part in pdf_parts)
+
+
+def test_run_sends_bytes_upload_with_explicit_pdf_metadata():
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run(
+        AGENT_ID,
+        prompt="segment this policy",
+        pdf_file=FileUpload.from_bytes(
+            b"%PDF-1.4\nbytes\n",
+            filename="policy.pdf",
+            mime_type="application/pdf",
+        ),
+    )
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["data"] == {"prompt": "segment this policy"}
+    assert len(kwargs["files"]) == 1
+    key, part = kwargs["files"][0]
+    assert key == "pdf_file"
+    assert part[0] == "policy.pdf"
+    assert part[1].getvalue() == b"%PDF-1.4\nbytes\n"
+    assert part[2] == "application/pdf"
+
+
+def test_run_sends_docx_path_with_office_mime_type(tmp_path):
+    document = tmp_path / "contract.docx"
+    document.write_bytes(b"PK\x03\x04docx")
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run(AGENT_ID, documents=FileUpload(path=str(document)))
+
+    key, part = request.call_args.kwargs["files"][0]
+    assert key == "documents"
+    assert part[0] == "contract.docx"
+    assert part[2] == (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    assert part[1].closed
+
+
+def test_run_streams_existing_string_path_instead_of_reading_into_memory(tmp_path):
+    document = tmp_path / "policy.pdf"
+    document.write_bytes(b"%PDF-1.4\nlocal path\n")
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run(AGENT_ID, pdf_file=str(document))
+
+    key, part = request.call_args.kwargs["files"][0]
+    assert key == "pdf_file"
+    assert part[0] == "policy.pdf"
+    assert part[1].name == str(document)
+    assert part[1].closed
+    assert part[2] == "application/pdf"
+
+
+def test_run_sends_path_string_list_as_repeated_file_fields(tmp_path):
+    first = tmp_path / "first.pdf"
+    second = tmp_path / "second.pdf"
+    first.write_bytes(b"%PDF-1.4\nfirst\n")
+    second.write_bytes(b"%PDF-1.4\nsecond\n")
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run(AGENT_ID, pdf_files=[str(first), str(second)])
+
+    parts = [
+        part for key, part in request.call_args.kwargs["files"] if key == "pdf_files"
+    ]
+    assert [part[0] for part in parts] == ["first.pdf", "second.pdf"]
+    assert all(part[1].closed for part in parts)
+    assert [part[2] for part in parts] == ["application/pdf", "application/pdf"]
+
+
+def test_run_rejects_raw_bytes_without_filename():
+    api, _ = _api(httpx.Response(200, json=JOB_ID))
+
+    with pytest.raises(ValueError, match="FileUpload.from_bytes"):
+        api.run(AGENT_ID, pdf_file=b"%PDF-1.4\nraw\n")
+
+
+def test_run_rejects_mixed_file_and_scalar_list(tmp_path):
+    document = tmp_path / "policy.pdf"
+    document.write_bytes(b"%PDF-1.4\nlocal\n")
+    api, _ = _api(httpx.Response(200, json=JOB_ID))
+
+    with pytest.raises(ValueError, match="mixes local file uploads"):
+        api.run(AGENT_ID, pdf_files=[str(document), "https://example.com/policy.pdf"])
+
+
+def test_run_keeps_urls_and_roe_file_ids_as_scalar_inputs():
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run(
+        AGENT_ID,
+        pdf_file="https://example.com/policy.pdf",
+        existing_file="00000000-0000-0000-0000-000000000999",
+    )
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["data"] == {
+        "pdf_file": "https://example.com/policy.pdf",
+        "existing_file": "00000000-0000-0000-0000-000000000999",
+    }
+    assert kwargs["files"] == []

--- a/tests/unit/test_agents_wrapper_transport.py
+++ b/tests/unit/test_agents_wrapper_transport.py
@@ -11,7 +11,6 @@ import pytest
 from roe.api.agents import AgentsAPI
 from roe.exceptions import NotFoundError
 from roe.models import FileUpload
-from roe.utils.inputs import build_execution_multipart
 
 ORG_ID = "00000000-0000-0000-0000-000000000123"
 AGENT_ID = "00000000-0000-0000-0000-000000000111"
@@ -134,14 +133,6 @@ def test_run_streams_existing_string_path_instead_of_reading_into_memory(tmp_pat
     assert part[1].name == str(document)
     assert part[1].closed
     assert part[2] == "application/pdf"
-
-
-def test_legacy_multipart_wrapper_rejects_sdk_opened_local_files(tmp_path):
-    document = tmp_path / "policy.pdf"
-    document.write_bytes(b"%PDF-1.4\nlocal path\n")
-
-    with pytest.raises(ValueError, match="build_execution_multipart_payload"):
-        build_execution_multipart({"pdf_file": str(document)})
 
 
 def test_run_sends_path_string_list_as_repeated_file_fields(tmp_path):

--- a/tests/unit/test_cli_agents.py
+++ b/tests/unit/test_cli_agents.py
@@ -1,0 +1,218 @@
+"""CLI coverage for agent file/PDF execution commands."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from roe import cli
+from roe.models import FileUpload
+
+ORG_ID = "00000000-0000-0000-0000-000000000123"
+AGENT_ID = "00000000-0000-0000-0000-000000000111"
+JOB_ID = "00000000-0000-0000-0000-000000000333"
+
+
+def _write_config(path):
+    path.write_text(
+        json.dumps(
+            {
+                "api_key": "test-key",
+                "organization_id": ORG_ID,
+                "base_url": "http://backend",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_cli_agent_run_help_exposes_pdf_file_inputs(capsys):
+    try:
+        cli.main(["agent", "run", "--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    output = capsys.readouterr().out
+    assert "roe agent run" in output
+    assert "--file" in output
+    assert "pdf_files=./document.pdf" in output
+
+
+def test_cli_agent_run_uploads_multiple_pdf_files(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.json"
+    _write_config(config_path)
+    first_pdf = tmp_path / "first.pdf"
+    second_pdf = tmp_path / "second.pdf"
+    first_pdf.write_bytes(b"%PDF-1.4\nfirst\n")
+    second_pdf.write_bytes(b"%PDF-1.4\nsecond\n")
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+    calls = []
+
+    class FakeJob:
+        id = JOB_ID
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append({"client": kwargs})
+            self.agents = SimpleNamespace(run=self.run)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def run(self, *args, **kwargs):
+            calls.append({"run": {"args": args, "kwargs": kwargs}})
+            return FakeJob()
+
+    monkeypatch.setattr(cli, "RoeClient", FakeClient)
+
+    result = cli.main(
+        [
+            "agent",
+            "run",
+            AGENT_ID,
+            "--input",
+            "prompt=Summarize these PDFs",
+            "--file",
+            f"pdf_files={first_pdf}",
+            "--file",
+            f"pdf_files={second_pdf}",
+            "--metadata",
+            "source=cli-test",
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    assert calls[0] == {
+        "client": {
+            "api_key": "test-key",
+            "organization_id": ORG_ID,
+            "base_url": "http://backend",
+            "timeout": None,
+        }
+    }
+    assert calls[1]["run"]["args"] == (AGENT_ID,)
+    kwargs = calls[1]["run"]["kwargs"]
+    assert kwargs["prompt"] == "Summarize these PDFs"
+    assert kwargs["metadata"] == {"source": "cli-test"}
+    assert kwargs["idempotency_key"] is None
+    assert [item.path for item in kwargs["pdf_files"]] == [
+        str(first_pdf),
+        str(second_pdf),
+    ]
+    assert all(isinstance(item, FileUpload) for item in kwargs["pdf_files"])
+    assert json.loads(capsys.readouterr().out) == {"job_id": JOB_ID}
+
+
+def test_cli_agent_run_wait_prints_result(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.json"
+    _write_config(config_path)
+    pdf_path = tmp_path / "document.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+    calls = []
+
+    class FakeJob:
+        id = JOB_ID
+
+        def wait(self, *args, **kwargs):
+            calls.append({"wait": {"args": args, "kwargs": kwargs}})
+            return {"job_id": JOB_ID, "status": 3}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.agents = SimpleNamespace(run=self.run)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def run(self, *args, **kwargs):
+            return FakeJob()
+
+    monkeypatch.setattr(cli, "RoeClient", FakeClient)
+
+    result = cli.main(
+        [
+            "agent",
+            "run",
+            AGENT_ID,
+            "--file",
+            f"pdf_files={pdf_path}",
+            "--wait",
+            "--poll-interval",
+            "0.5",
+            "--job-timeout",
+            "30",
+            "--json",
+        ]
+    )
+
+    assert result == 0
+    assert calls == [
+        {"wait": {"args": (), "kwargs": {"interval": 0.5, "timeout": 30.0}}}
+    ]
+    assert json.loads(capsys.readouterr().out) == {"job_id": JOB_ID, "status": 3}
+
+
+def test_cli_agent_run_rejects_missing_file(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.json"
+    _write_config(config_path)
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+
+    result = cli.main(
+        [
+            "agent",
+            "run",
+            AGENT_ID,
+            "--file",
+            f"pdf_files={tmp_path / 'missing.pdf'}",
+        ]
+    )
+
+    assert result == 1
+    assert "Agent input file not found" in capsys.readouterr().err
+
+
+def test_cli_agent_status_and_result_route_to_jobs_api(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.json"
+    _write_config(config_path)
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+    calls = []
+
+    class FakeJobs:
+        def retrieve_status(self, job_id):
+            calls.append(("status", job_id))
+            return {"job_id": job_id, "status": 1}
+
+        def retrieve_result(self, job_id):
+            calls.append(("result", job_id))
+            return {"job_id": job_id, "outputs": [{"value": "done"}]}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.agents = SimpleNamespace(jobs=FakeJobs())
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(cli, "RoeClient", FakeClient)
+
+    status_result = cli.main(["agent", "status", JOB_ID, "--json"])
+    result_out = json.loads(capsys.readouterr().out)
+    result_result = cli.main(["agent", "result", JOB_ID, "--json"])
+    final_out = json.loads(capsys.readouterr().out)
+
+    assert status_result == 0
+    assert result_result == 0
+    assert calls == [("status", JOB_ID), ("result", JOB_ID)]
+    assert result_out == {"job_id": JOB_ID, "status": 1}
+    assert final_out == {"job_id": JOB_ID, "outputs": [{"value": "done"}]}

--- a/tests/unit/test_cli_agents.py
+++ b/tests/unit/test_cli_agents.py
@@ -39,6 +39,21 @@ def test_cli_agent_run_help_exposes_pdf_file_inputs(capsys):
     assert "pdf_files=./document.pdf" in output
 
 
+def test_cli_top_level_help_and_version_explain_upload_version(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--help"])
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "roe-ai>=1.0.803" in output
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--version"])
+
+    assert exc.value.code == 0
+    assert "roe-ai " in capsys.readouterr().out
+
+
 def test_cli_agent_run_uploads_multiple_pdf_files(tmp_path, monkeypatch, capsys):
     config_path = tmp_path / "config.json"
     _write_config(config_path)

--- a/tests/unit/test_cli_agents.py
+++ b/tests/unit/test_cli_agents.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import pytest
 from types import SimpleNamespace
 
 from roe import cli
@@ -177,6 +178,50 @@ def test_cli_agent_run_rejects_missing_file(tmp_path, monkeypatch, capsys):
 
     assert result == 1
     assert "Agent input file not found" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_error"),
+    [
+        (["--input", "prompt"], "--input must be in KEY=VALUE form."),
+        (["--input", "=summarize"], "--input key is required."),
+        (["--file", "pdf_files"], "--file must be in KEY=VALUE form."),
+        (
+            ["--input", "prompt=one", "--input", "prompt=two"],
+            "Duplicate agent input key: prompt",
+        ),
+        (
+            ["--metadata-json", "[1, 2]"],
+            "--metadata-json must be a JSON object.",
+        ),
+        (
+            ["--metadata-json", "{"],
+            "--metadata-json must be valid JSON.",
+        ),
+    ],
+)
+def test_cli_agent_run_rejects_malformed_inputs(args, expected_error, capsys):
+    result = cli.main(["agent", "run", AGENT_ID, *args])
+
+    assert result == 1
+    assert expected_error in capsys.readouterr().err
+
+
+def test_cli_agent_run_rejects_scalar_and_file_for_same_key(capsys):
+    result = cli.main(
+        [
+            "agent",
+            "run",
+            AGENT_ID,
+            "--input",
+            "pdf_files=already-uploaded-file-id",
+            "--file",
+            "pdf_files=./document.pdf",
+        ]
+    )
+
+    assert result == 1
+    assert "cannot be both --input and --file" in capsys.readouterr().err
 
 
 def test_cli_agent_status_and_result_route_to_jobs_api(tmp_path, monkeypatch, capsys):

--- a/tests/unit/test_cli_agents.py
+++ b/tests/unit/test_cli_agents.py
@@ -7,7 +7,7 @@ import pytest
 from types import SimpleNamespace
 
 from roe import cli
-from roe.models import FileUpload
+from roe.models import FileUpload, JobStatus
 
 ORG_ID = "00000000-0000-0000-0000-000000000123"
 AGENT_ID = "00000000-0000-0000-0000-000000000111"
@@ -174,6 +174,58 @@ def test_cli_agent_run_wait_prints_result(tmp_path, monkeypatch, capsys):
         {"wait": {"args": (), "kwargs": {"interval": 0.5, "timeout": 30.0}}}
     ]
     assert json.loads(capsys.readouterr().out) == {"job_id": JOB_ID, "status": 3}
+
+
+def test_cli_agent_run_wait_returns_nonzero_for_failed_job(
+    tmp_path, monkeypatch, capsys
+):
+    config_path = tmp_path / "config.json"
+    _write_config(config_path)
+    pdf_path = tmp_path / "document.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+    monkeypatch.setenv("ROE_CONFIG_FILE", str(config_path))
+
+    class FakeJob:
+        id = JOB_ID
+
+        def wait(self, *args, **kwargs):
+            return {
+                "job_id": JOB_ID,
+                "status": JobStatus.FAILURE,
+                "error_message": "agent failed",
+            }
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.agents = SimpleNamespace(run=self.run)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def run(self, *args, **kwargs):
+            return FakeJob()
+
+    monkeypatch.setattr(cli, "RoeClient", FakeClient)
+
+    result = cli.main(
+        [
+            "agent",
+            "run",
+            AGENT_ID,
+            "--file",
+            f"pdf_files={pdf_path}",
+            "--wait",
+            "--json",
+        ]
+    )
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["status"] == JobStatus.FAILURE
+    assert "Agent job failed: agent failed" in captured.err
 
 
 def test_cli_agent_run_rejects_missing_file(tmp_path, monkeypatch, capsys):

--- a/tests/unit/test_cli_process_smoke.py
+++ b/tests/unit/test_cli_process_smoke.py
@@ -16,6 +16,7 @@ AGENT_ID = "00000000-0000-0000-0000-000000000111"
 VERSION_ID = "00000000-0000-0000-0000-000000000222"
 JOB_ID = "00000000-0000-0000-0000-000000000333"
 UPLOAD_ID = "00000000-0000-0000-0000-000000000444"
+LARGE_DOCX_SIZE = 6 * 1024 * 1024
 
 
 def _write_config(path: Path, base_url: str) -> None:
@@ -101,8 +102,17 @@ def test_cli_process_agent_pdf_run_and_table_upload_round_trip(tmp_path):
                 assert b'filename="first.pdf"' in body
                 assert b'filename="second.pdf"' in body
                 assert body.count(b"Content-Type: application/pdf") == 2
+                assert body.count(b'name="documents"') == 1
+                assert b'filename="handbook.docx"' in body
+                assert (
+                    b"Content-Type: application/vnd.openxmlformats-officedocument."
+                    b"wordprocessingml.document"
+                ) in body
+                assert b"large-docx-marker" in body
                 assert b'name="prompt"' in body
                 assert b"Summarize these PDFs" in body
+                assert b'name="source_url"' in body
+                assert b"https://example.com/manual.pdf" in body
                 assert b'name="metadata"' in body
                 assert b'"flow": "process"' in body
                 assert b'"source": "cli"' in body
@@ -202,8 +212,13 @@ def test_cli_process_agent_pdf_run_and_table_upload_round_trip(tmp_path):
     try:
         first_pdf = tmp_path / "first.pdf"
         second_pdf = tmp_path / "second.pdf"
+        handbook = tmp_path / "handbook.docx"
         first_pdf.write_bytes(b"%PDF-1.4\nfirst\n")
         second_pdf.write_bytes(b"%PDF-1.4\nsecond\n")
+        handbook.write_bytes(
+            b"PK\x03\x04large-docx-marker\n"
+            + (b"x" * (LARGE_DOCX_SIZE - len(b"PK\x03\x04large-docx-marker\n")))
+        )
         agent = _run_cli(
             tmp_path,
             config_path,
@@ -212,10 +227,14 @@ def test_cli_process_agent_pdf_run_and_table_upload_round_trip(tmp_path):
             AGENT_ID,
             "--input",
             "prompt=Summarize these PDFs",
+            "--input",
+            "source_url=https://example.com/manual.pdf",
             "--file",
             f"pdf_files={first_pdf}",
             "--file",
             f"pdf_files={second_pdf}",
+            "--file",
+            f"documents={handbook}",
             "--metadata-json",
             '{"flow":"process"}',
             "--metadata",
@@ -265,3 +284,4 @@ def test_cli_process_agent_pdf_run_and_table_upload_round_trip(tmp_path):
         {"kind": "presigned_put", "bytes": 20},
         {"kind": "table_complete"},
     ]
+    assert events[0]["bytes"] > LARGE_DOCX_SIZE

--- a/tests/unit/test_cli_process_smoke.py
+++ b/tests/unit/test_cli_process_smoke.py
@@ -1,0 +1,267 @@
+"""Subprocess-level CLI smoke tests against a local HTTP server."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from threading import Thread
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+ORG_ID = "00000000-0000-0000-0000-000000000123"
+AGENT_ID = "00000000-0000-0000-0000-000000000111"
+VERSION_ID = "00000000-0000-0000-0000-000000000222"
+JOB_ID = "00000000-0000-0000-0000-000000000333"
+UPLOAD_ID = "00000000-0000-0000-0000-000000000444"
+
+
+def _write_config(path: Path, base_url: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "api_key": "test-key",
+                "organization_id": ORG_ID,
+                "base_url": base_url,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_cli(
+    tmp_path: Path, config_path: Path, *args: str
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["ROE_CONFIG_FILE"] = str(config_path)
+    env["PYTHONPATH"] = os.pathsep.join(
+        item
+        for item in [
+            str(Path(__file__).resolve().parents[2] / "src"),
+            env.get("PYTHONPATH", ""),
+        ]
+        if item
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "roe.cli", *args],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_process_agent_pdf_run_and_table_upload_round_trip(tmp_path):
+    events: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+        def _body(self) -> bytes:
+            length = int(self.headers.get("Content-Length") or "0")
+            return self.rfile.read(length)
+
+        def _send_json(self, status: int, payload: object) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_empty(self, status: int) -> None:
+            self.send_response(status)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def _assert_roe_headers(self) -> None:
+            assert self.headers["Authorization"] == "Bearer test-key"
+            assert self.headers["X-Organization-Id"] == ORG_ID
+            assert self.headers["X-Roe-Organization-Id"] == ORG_ID
+
+        def do_POST(self) -> None:
+            parsed = urlparse(self.path)
+            query = parse_qs(parsed.query)
+            self._assert_roe_headers()
+
+            if parsed.path == f"/v1/agents/run/{AGENT_ID}/async/":
+                assert query == {"organization_id": [ORG_ID]}
+                assert self.headers["Idempotency-Key"] == "idem-process"
+                assert self.headers["x-roe-skip-retry"] == "1"
+                content_type = self.headers["Content-Type"]
+                assert content_type.startswith("multipart/form-data; boundary=")
+                body = self._body()
+                assert body.count(b'name="pdf_files"') == 2
+                assert b'filename="first.pdf"' in body
+                assert b'filename="second.pdf"' in body
+                assert body.count(b"Content-Type: application/pdf") == 2
+                assert b'name="prompt"' in body
+                assert b"Summarize these PDFs" in body
+                assert b'name="metadata"' in body
+                assert b'"flow": "process"' in body
+                assert b'"source": "cli"' in body
+                events.append({"kind": "agent_run", "bytes": len(body)})
+                self._send_json(200, JOB_ID)
+                return
+
+            if parsed.path == "/v1/tables/upload/presigned-url/":
+                payload = json.loads(self._body())
+                assert payload == {
+                    "content_type": "text/csv",
+                    "filename": "flights.csv",
+                    "organization_id": ORG_ID,
+                    "table_name": "flights",
+                    "with_headers": False,
+                }
+                events.append({"kind": "table_create"})
+                self._send_json(
+                    201,
+                    {
+                        "upload_id": UPLOAD_ID,
+                        "upload_url": f"http://{self.server.server_address[0]}:{self.server.server_address[1]}/presigned/flights.csv",
+                        "headers": {
+                            "Authorization": "Bearer should-not-leak",
+                            "X-Organization-Id": "should-not-leak",
+                            "X-Roe-Organization-Id": "should-not-leak",
+                            "x-amz-meta-test": "ok",
+                        },
+                    },
+                )
+                return
+
+            if parsed.path == f"/v1/tables/upload/{UPLOAD_ID}/complete/":
+                assert self._body() == b""
+                events.append({"kind": "table_complete"})
+                self._send_json(202, {"upload_id": UPLOAD_ID, "status": "COMPLETED"})
+                return
+
+            self._send_json(404, {"detail": f"unexpected POST {self.path}"})
+
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            query = parse_qs(parsed.query)
+            self._assert_roe_headers()
+            assert query == {"organization_id": [ORG_ID]}
+
+            if parsed.path == f"/v1/agents/jobs/{JOB_ID}/status/":
+                events.append({"kind": "agent_status"})
+                self._send_json(200, {"status": 3, "timestamp": 123})
+                return
+
+            if parsed.path == f"/v1/agents/jobs/{JOB_ID}/result/":
+                events.append({"kind": "agent_result"})
+                self._send_json(
+                    200,
+                    {
+                        "agent_id": AGENT_ID,
+                        "agent_version_id": VERSION_ID,
+                        "inputs": [],
+                        "input_tokens": None,
+                        "output_tokens": None,
+                        "outputs": [
+                            {
+                                "key": "answer",
+                                "data_type": "text/plain",
+                                "value": "done",
+                            }
+                        ],
+                    },
+                )
+                return
+
+            self._send_json(404, {"detail": f"unexpected GET {self.path}"})
+
+        def do_PUT(self) -> None:
+            parsed = urlparse(self.path)
+            assert parsed.path == "/presigned/flights.csv"
+            lower_headers = {key.lower(): value for key, value in self.headers.items()}
+            assert "authorization" not in lower_headers
+            assert "x-organization-id" not in lower_headers
+            assert "x-roe-organization-id" not in lower_headers
+            assert lower_headers["x-amz-meta-test"] == "ok"
+            body = self._body()
+            assert body == b"origin,dest\nSFO,JFK\n"
+            events.append({"kind": "presigned_put", "bytes": len(body)})
+            self._send_empty(200)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    config_path = tmp_path / "config.json"
+    _write_config(
+        config_path,
+        f"http://{server.server_address[0]}:{server.server_address[1]}",
+    )
+
+    try:
+        first_pdf = tmp_path / "first.pdf"
+        second_pdf = tmp_path / "second.pdf"
+        first_pdf.write_bytes(b"%PDF-1.4\nfirst\n")
+        second_pdf.write_bytes(b"%PDF-1.4\nsecond\n")
+        agent = _run_cli(
+            tmp_path,
+            config_path,
+            "agent",
+            "run",
+            AGENT_ID,
+            "--input",
+            "prompt=Summarize these PDFs",
+            "--file",
+            f"pdf_files={first_pdf}",
+            "--file",
+            f"pdf_files={second_pdf}",
+            "--metadata-json",
+            '{"flow":"process"}',
+            "--metadata",
+            "source=cli",
+            "--idempotency-key",
+            "idem-process",
+            "--wait",
+            "--poll-interval",
+            "0.01",
+            "--job-timeout",
+            "2",
+            "--json",
+        )
+        assert agent.returncode == 0, agent.stderr
+        agent_payload = json.loads(agent.stdout)
+        assert agent_payload["status"] == 3
+        assert agent_payload["outputs"][0]["value"] == "done"
+
+        csv_path = tmp_path / "flights.csv"
+        csv_path.write_bytes(b"origin,dest\nSFO,JFK\n")
+        table = _run_cli(
+            tmp_path,
+            config_path,
+            "table",
+            "upload",
+            str(csv_path),
+            "--table",
+            "flights",
+            "--no-headers",
+            "--json",
+        )
+        assert table.returncode == 0, table.stderr
+        assert json.loads(table.stdout) == {
+            "upload_id": UPLOAD_ID,
+            "status": "COMPLETED",
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert events == [
+        {"kind": "agent_run", "bytes": events[0]["bytes"]},
+        {"kind": "agent_status"},
+        {"kind": "agent_result"},
+        {"kind": "table_create"},
+        {"kind": "presigned_put", "bytes": 20},
+        {"kind": "table_complete"},
+    ]

--- a/tests/unit/test_tables.py
+++ b/tests/unit/test_tables.py
@@ -626,7 +626,5 @@ def test_cli_table_status_routes_to_upload_status(monkeypatch, tmp_path, capsys)
     )
 
     assert result == 0
-    assert calls[1] == {
-        "upload_status": "00000000-0000-0000-0000-000000000555"
-    }
+    assert calls[1] == {"upload_status": "00000000-0000-0000-0000-000000000555"}
     assert json.loads(capsys.readouterr().out)["status"] == "COMPLETED"


### PR DESCRIPTION
## Summary
- add `roe agent run` for local file/PDF inputs, including repeated `--file KEY=PATH` for multi-file agent inputs
- add `roe agent status` and `roe agent result` helpers for async job follow-up
- preserve repeated multipart file fields in the SDK transport and close SDK-opened file handles after requests
- add subprocess-level local HTTP smoke coverage for actual CLI multipart uploads and table presigned upload header stripping
- document command-line usage and clarify CLI auth vs Python SDK auth in the README

## Validation
- `uv run pytest`
- `uv run pytest tests/unit/test_cli_agents.py tests/unit/test_cli_process_smoke.py tests/unit/test_agents_wrapper_transport.py tests/unit/test_tables.py`
- `uv run pytest tests/unit/test_cli_agents.py tests/unit/test_cli_process_smoke.py tests/unit/test_tables.py`
- `uv run ruff check .`
- `uv run ruff format --check src/roe/cli.py src/roe/utils/inputs.py src/roe/utils/_dynamic_call.py tests/unit/test_cli_agents.py tests/unit/test_cli_process_smoke.py tests/unit/test_agents_wrapper_transport.py tests/unit/test_tables.py`
- `bash scripts/generate-sdk`, followed by tracked codegen drift check
