### PR TITLE
[codex] Share one poll-until-terminal loop across wait helpers

### DIFF
--- a/src/roe/api/table_upload_helpers.py
+++ b/src/roe/api/table_upload_helpers.py
@@ -11,6 +11,7 @@ from uuid import UUID
 import httpx
 
 from roe.exceptions import RoeAPIException, translate_response
+from roe.utils.polling import poll_until
 
 TERMINAL_UPLOAD_STATUSES = frozenset({"COMPLETED", "FAILED", "EXPIRED"})
 PRESIGNED_UPLOAD_TIMEOUT_SECONDS = 300.0
@@ -118,21 +119,25 @@ class TableUploadHelpersMixin:
         poll_interval: float = 2.0,
         timeout: float | None = None,
     ) -> dict[str, Any]:
-        """Poll a table upload session until it reaches a terminal status."""
+        """Poll a table upload session until it reaches a terminal status.
+
+        ``poll_interval`` is the initial interval; ``poll_until`` applies
+        capped exponential backoff between checks.
+        """
         upload_id = _coerce_upload_id(upload_id)
         if poll_interval <= 0:
             raise ValueError("poll_interval must be greater than 0")
-        deadline = time.monotonic() + timeout if timeout is not None else None
-        while True:
+
+        def _check() -> dict[str, Any] | None:
             result = self.upload_status(upload_id=upload_id)
-            if result.get("status") in TERMINAL_UPLOAD_STATUSES:
-                return result
-            if deadline is not None and time.monotonic() >= deadline:
-                raise TimeoutError(f"Timed out waiting for table upload {upload_id}")
-            sleep_for = poll_interval
-            if deadline is not None:
-                sleep_for = min(sleep_for, max(0.0, deadline - time.monotonic()))
-            time.sleep(sleep_for)
+            return result if result.get("status") in TERMINAL_UPLOAD_STATUSES else None
+
+        return poll_until(
+            _check,
+            interval=poll_interval,
+            timeout=timeout,
+            timeout_message=f"Timed out waiting for table upload {upload_id}",
+        )
 
     def _request_json(
         self,

--- a/src/roe/cli.py
+++ b/src/roe/cli.py
@@ -127,7 +127,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--poll-interval",
         type=float,
         default=5.0,
-        help="Seconds between job status checks when --wait is used.",
+        help="Initial seconds between job status checks when --wait is used (backs off up to 15s).",
     )
     run.add_argument(
         "--job-timeout",
@@ -184,7 +184,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--poll-interval",
         type=float,
         default=2.0,
-        help="Seconds between status checks when --wait is used.",
+        help="Initial seconds between status checks when --wait is used (backs off up to 15s).",
     )
     upload.add_argument(
         "--upload-timeout",

--- a/src/roe/models/job.py
+++ b/src/roe/models/job.py
@@ -8,7 +8,6 @@ returned to callers come from the generated client.
 
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -16,6 +15,7 @@ from roe._generated.models.agent_job_result_item import AgentJobResultItem
 from roe._generated.models.agent_job_result_response import AgentJobResultResponse
 from roe._generated.models.agent_job_status import AgentJobStatus
 from roe.exceptions import NotFoundError, RoeAPIException
+from roe.utils.polling import poll_until
 
 if TYPE_CHECKING:
     from roe.api.agents import AgentsAPI
@@ -109,32 +109,33 @@ class Job:
             raise ValueError(f"timeout must be positive, got {timeout}")
 
         effective_timeout = timeout if timeout is not None else self._timeout_seconds
-        start_time = time.time()
 
         from roe._generated.types import Unset
 
-        while True:
+        def _check() -> AgentJobResultResponse | None:
             status = self.retrieve_status()
+            if status.status not in _TERMINAL_STATUSES:
+                return None
             error_message = (
                 None if isinstance(status.error_message, Unset) else status.error_message
             )
+            is_failed = status.status in _FAILED_STATUSES
+            try:
+                result = self.retrieve_result()
+            except RoeAPIException:
+                if not is_failed:
+                    raise
+                return _empty_result(status.status, error_message)
+            return _attach_status(result, status.status, error_message)
 
-            if status.status in _TERMINAL_STATUSES:
-                is_failed = status.status in _FAILED_STATUSES
-                try:
-                    result = self.retrieve_result()
-                except RoeAPIException:
-                    if not is_failed:
-                        raise
-                    return _empty_result(status.status, error_message)
-                return _attach_status(result, status.status, error_message)
-
-            if (time.time() - start_time) > effective_timeout:
-                raise TimeoutError(
-                    f"Job {self._job_id} did not complete within {effective_timeout} seconds"
-                )
-
-            time.sleep(interval)
+        return poll_until(
+            _check,
+            interval=interval,
+            timeout=effective_timeout,
+            timeout_message=(
+                f"Job {self._job_id} did not complete within {effective_timeout} seconds"
+            ),
+        )
 
     def retrieve_status(self) -> AgentJobStatus:
         """Generated ``AgentJobStatus`` for the job."""
@@ -198,66 +199,68 @@ class JobBatch:
             raise ValueError(f"timeout must be positive, got {timeout}")
 
         effective_timeout = timeout if timeout is not None else self._timeout_seconds
-        start_time = time.time()
 
-        while len(self._completed_jobs) < len(self._job_ids):
-            pending_job_ids = [
-                job_id
-                for job_id in self._job_ids
-                if job_id not in self._completed_jobs
-            ]
+        try:
+            return poll_until(
+                self._poll_round,
+                interval=interval,
+                timeout=effective_timeout,
+            )
+        except TimeoutError:
+            if raise_on_timeout:
+                remaining = set(self._job_ids) - set(self._completed_jobs)
+                raise TimeoutError(
+                    f"Jobs {remaining} did not complete within {effective_timeout} seconds"
+                ) from None
+            return [self._completed_jobs.get(job_id) for job_id in self._job_ids]
 
-            if not pending_job_ids:
-                break
+    def _poll_round(self) -> list[AgentJobResultItem | None] | None:
+        """One status/result fetch round; the full result list once all jobs finish."""
+        pending_job_ids = [
+            job_id for job_id in self._job_ids if job_id not in self._completed_jobs
+        ]
+        if not pending_job_ids:
+            return [self._completed_jobs.get(job_id) for job_id in self._job_ids]
 
-            status_batch = self.agents_api.jobs.retrieve_status_many(pending_job_ids)
+        status_batch = self.agents_api.jobs.retrieve_status_many(pending_job_ids)
 
-            completed_in_this_batch: list[str] = []
-            for status_item in status_batch:
-                job_id = self._extract_id(status_item)
-                if job_id is None:
-                    continue
-                stat_code = self._extract_status(status_item)
-                if stat_code in _TERMINAL_STATUSES:
-                    completed_in_this_batch.append(job_id)
-                if stat_code is not None:
-                    self._job_statuses[job_id] = {
-                        "status": stat_code,
-                        "error_message": self._extract_error_message(status_item),
-                        "timestamp": self._extract_timestamp(status_item),
-                    }
+        completed_in_this_batch: list[str] = []
+        for status_item in status_batch:
+            job_id = self._extract_id(status_item)
+            if job_id is None:
+                continue
+            stat_code = self._extract_status(status_item)
+            if stat_code in _TERMINAL_STATUSES:
+                completed_in_this_batch.append(job_id)
+            if stat_code is not None:
+                self._job_statuses[job_id] = {
+                    "status": stat_code,
+                    "error_message": self._extract_error_message(status_item),
+                    "timestamp": self._extract_timestamp(status_item),
+                }
 
-            if completed_in_this_batch:
-                result_batch = self.agents_api.jobs.retrieve_result_many(
-                    completed_in_this_batch
+        if completed_in_this_batch:
+            result_batch = self.agents_api.jobs.retrieve_result_many(
+                completed_in_this_batch
+            )
+            for result_item in result_batch:
+                job_id = str(result_item.id)
+                cached = self._job_statuses.get(job_id)
+                is_failed = (
+                    cached is not None and cached["status"] in _FAILED_STATUSES
                 )
-                for result_item in result_batch:
-                    job_id = str(result_item.id)
-                    cached = self._job_statuses.get(job_id)
-                    is_failed = (
-                        cached is not None and cached["status"] in _FAILED_STATUSES
-                    )
-                    if (
-                        result_item.agent_id is None
-                        or result_item.agent_version_id is None
-                    ):
-                        if not is_failed:
-                            raise NotFoundError(
-                                f"Job {job_id} not found or has been deleted"
-                            )
-                    self._completed_jobs[job_id] = result_item
-
-            if len(self._completed_jobs) < len(self._job_ids):
-                if (time.time() - start_time) > effective_timeout:
-                    if raise_on_timeout:
-                        remaining = set(self._job_ids) - set(self._completed_jobs)
-                        raise TimeoutError(
-                            f"Jobs {remaining} did not complete within {effective_timeout} seconds"
+                if (
+                    result_item.agent_id is None
+                    or result_item.agent_version_id is None
+                ):
+                    if not is_failed:
+                        raise NotFoundError(
+                            f"Job {job_id} not found or has been deleted"
                         )
-                    break
+                self._completed_jobs[job_id] = result_item
 
-                time.sleep(interval)
-
+        if len(self._completed_jobs) < len(self._job_ids):
+            return None
         return [self._completed_jobs.get(job_id) for job_id in self._job_ids]
 
     def retrieve_status(self) -> dict[str, AgentJobStatus]:

--- a/src/roe/models/job.py
+++ b/src/roe/models/job.py
@@ -104,6 +104,9 @@ class Job:
         ``status`` (int code) and any ``error_message`` attached via the
         model's ``additional_properties`` dict — accessible as
         ``result["status"]`` and ``result["error_message"]``.
+
+        ``interval`` is the initial poll interval; subsequent polls back off
+        (capped at 15s, see ``roe.utils.polling.poll_until``).
         """
         if timeout is not None and timeout <= 0:
             raise ValueError(f"timeout must be positive, got {timeout}")
@@ -194,6 +197,9 @@ class JobBatch:
 
         ``AgentJobResultItem.status`` (the int code) is already populated by
         the batch results endpoint — no extra attachment needed.
+
+        ``interval`` is the initial poll interval; subsequent polls back off
+        (capped at 15s, see ``roe.utils.polling.poll_until``).
         """
         if timeout is not None and timeout <= 0:
             raise ValueError(f"timeout must be positive, got {timeout}")

--- a/src/roe/utils/polling.py
+++ b/src/roe/utils/polling.py
@@ -1,0 +1,49 @@
+"""Shared poll-until-terminal loop for SDK wait helpers."""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+DEFAULT_BACKOFF_FACTOR = 1.5
+DEFAULT_MAX_INTERVAL = 15.0
+DEFAULT_JITTER = 0.1
+
+
+def poll_until(
+    check: Callable[[], T | None],
+    *,
+    interval: float,
+    timeout: float | None,
+    backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+    max_interval: float = DEFAULT_MAX_INTERVAL,
+    jitter: float = DEFAULT_JITTER,
+    timeout_message: str = "Timed out while polling",
+) -> T:
+    """Call ``check`` until it returns non-``None``, with capped backoff between calls.
+
+    ``interval`` is the first sleep; later sleeps grow by ``backoff_factor`` up
+    to ``max_interval``, each randomized by +/- ``jitter`` fraction. Sleeps are
+    clamped to the remaining ``timeout`` (measured from before the first
+    check); when the deadline passes without a result, ``TimeoutError`` is
+    raised with ``timeout_message``. ``timeout=None`` polls forever. Callers
+    validate their own interval/timeout arguments.
+    """
+    deadline = time.monotonic() + timeout if timeout is not None else None
+    sleep_for = interval
+    while True:
+        result = check()
+        if result is not None:
+            return result
+        if deadline is not None and time.monotonic() >= deadline:
+            raise TimeoutError(timeout_message)
+        delay = sleep_for
+        if jitter:
+            delay *= 1.0 + random.uniform(-jitter, jitter)
+        if deadline is not None:
+            delay = min(delay, max(0.0, deadline - time.monotonic()))
+        time.sleep(delay)
+        sleep_for = min(sleep_for * backoff_factor, max_interval)

--- a/src/roe/utils/polling.py
+++ b/src/roe/utils/polling.py
@@ -29,9 +29,12 @@ def poll_until(
     to ``max_interval``, each randomized by +/- ``jitter`` fraction. Sleeps are
     clamped to the remaining ``timeout`` (measured from before the first
     check); when the deadline passes without a result, ``TimeoutError`` is
-    raised with ``timeout_message``. ``timeout=None`` polls forever. Callers
-    validate their own interval/timeout arguments.
+    raised with ``timeout_message``. ``timeout=None`` polls forever;
+    ``timeout=0`` checks exactly once. Callers validate ``timeout`` semantics
+    of their own public APIs.
     """
+    if interval <= 0:
+        raise ValueError("interval must be greater than 0")
     deadline = time.monotonic() + timeout if timeout is not None else None
     sleep_for = interval
     while True:

--- a/tests/unit/test_polling.py
+++ b/tests/unit/test_polling.py
@@ -1,0 +1,112 @@
+"""Unit tests for the shared poll_until helper."""
+
+import pytest
+
+from roe.utils import polling
+from roe.utils.polling import poll_until
+
+
+class FakeClock:
+    """Deterministic monotonic clock; sleeping advances time."""
+
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = FakeClock()
+    monkeypatch.setattr(polling.time, "monotonic", fake.monotonic)
+    monkeypatch.setattr(polling.time, "sleep", fake.sleep)
+    return fake
+
+
+def test_poll_until_returns_first_truthy_result_without_sleeping(clock):
+    result = poll_until(lambda: {"status": "COMPLETED"}, interval=2.0, timeout=30.0)
+
+    assert result == {"status": "COMPLETED"}
+    assert clock.sleeps == []
+
+
+def test_poll_until_applies_capped_exponential_backoff(clock):
+    results = iter([None, None, None, None, None, "done"])
+
+    result = poll_until(
+        lambda: next(results),
+        interval=4.0,
+        timeout=None,
+        backoff_factor=2.0,
+        max_interval=10.0,
+        jitter=0.0,
+    )
+
+    assert result == "done"
+    assert clock.sleeps == [4.0, 8.0, 10.0, 10.0, 10.0]
+
+
+def test_poll_until_jitter_stays_within_bounds(clock):
+    results = iter([None, None, None, "done"])
+
+    poll_until(
+        lambda: next(results),
+        interval=10.0,
+        timeout=None,
+        backoff_factor=1.0,
+        jitter=0.1,
+    )
+
+    assert len(clock.sleeps) == 3
+    for sleep in clock.sleeps:
+        assert 9.0 <= sleep <= 11.0
+
+
+def test_poll_until_clamps_final_sleep_to_deadline_and_times_out(clock):
+    calls = []
+
+    def check():
+        calls.append(clock.now)
+        return None
+
+    with pytest.raises(TimeoutError, match="upload abc"):
+        poll_until(
+            check,
+            interval=4.0,
+            timeout=10.0,
+            backoff_factor=2.0,
+            jitter=0.0,
+            timeout_message="Timed out waiting for upload abc",
+        )
+
+    # Sleeps: 4.0, then 8.0 clamped to the 6.0 remaining before the deadline.
+    assert clock.sleeps == [4.0, 6.0]
+    assert len(calls) == 3
+
+
+def test_poll_until_timeout_zero_checks_once_then_raises(clock):
+    calls = []
+
+    def check():
+        calls.append(clock.now)
+        return None
+
+    with pytest.raises(TimeoutError):
+        poll_until(check, interval=1.0, timeout=0.0)
+
+    assert len(calls) == 1
+    assert clock.sleeps == []
+
+
+def test_poll_until_returns_empty_container_results(clock):
+    # Falsy-but-not-None results (e.g. an empty batch list) terminate polling.
+    result = poll_until(lambda: [], interval=1.0, timeout=5.0)
+
+    assert result == []
+    assert clock.sleeps == []

--- a/tests/unit/test_polling.py
+++ b/tests/unit/test_polling.py
@@ -110,3 +110,10 @@ def test_poll_until_returns_empty_container_results(clock):
 
     assert result == []
     assert clock.sleeps == []
+
+
+def test_poll_until_rejects_non_positive_interval(clock):
+    with pytest.raises(ValueError, match="interval"):
+        poll_until(lambda: None, interval=0, timeout=5.0)
+
+    assert clock.sleeps == []


### PR DESCRIPTION
## Summary

`wait_for_upload`, `Job.wait`, and `JobBatch.wait` each hand-rolled a fixed-interval `time.sleep` loop. A multi-minute table import polled at the fixed 2s default costs 100+ status calls.

- New `src/roe/utils/polling.py` with `poll_until(check, *, interval, timeout, backoff_factor=1.5, max_interval=15.0, jitter=0.1, timeout_message=...)`: deadline-clamped sleeps, capped exponential backoff, +/-10% jitter.
- `wait_for_upload`, `Job.wait`, and `JobBatch.wait` now delegate their loop/timeout/sleep mechanics to it. **Public signatures unchanged**; `interval`/`poll_interval` is now the *initial* interval. `JobBatch.wait` keeps its `raise_on_timeout=False` partial-results behavior and its remaining-jobs timeout message.
- The 15s backoff cap keeps the backend's stale-import recovery (which is driven by status polls) timely.

Stacked on #49 (`codex/pdf-upload-cli`).

## Test Plan

- [x] `uv run pytest` — 82 passed (6 new in `tests/unit/test_polling.py`: immediate return, backoff sequence, jitter bounds, deadline clamp, `timeout=0`, falsy-but-not-None results)
- [x] `uv run ruff check` — clean
- [x] Existing wait tests pass unchanged (including `wait_for_upload` `timeout=0` semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)