### PR TITLE
[codex] use gpt-5.5 in Python SDK examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ agent = client.agents.create(
         {"key": "text", "data_type": "text/plain", "description": "Item description"},
     ],
     engine_config={
-        "model": "gpt-4.1-2025-04-14",
+        "model": "gpt-5.5-2026-04-23",
         "text": "${text}",
         "instruction": "Analyze this product listing. Is it counterfeit?",
         "output_schema": {
@@ -176,7 +176,7 @@ agent = client.agents.create(
         {"key": "pdf_files", "data_type": "application/pdf", "description": "Resume PDF"},
     ],
     engine_config={
-        "model": "gpt-4.1-2025-04-14",
+        "model": "gpt-5.5-2026-04-23",
         "pdf_files": "${pdf_files}",
         "instructions": "Extract candidate information from this resume.",
         "output_schema": {
@@ -207,7 +207,7 @@ agent = client.agents.create(
     ],
     engine_config={
         "url": "${url}",
-        "model": "gpt-4.1-2025-04-14",
+        "model": "gpt-5.5-2026-04-23",
         "instruction": "Extract company information from this website.",
         "vision_mode": False,
         "crawl_config": {

--- a/SDK_EXAMPLES.md
+++ b/SDK_EXAMPLES.md
@@ -36,7 +36,7 @@ result = client.agents.create(
     name="name",  # required
     engine_class_id="engine_class_id",  # required
     input_definitions=[{"key": "text", "data_type": "text/plain"}],  # optional
-    engine_config={"model": "gpt-4.1"},  # optional
+    engine_config={"model": "gpt-5.5-2026-04-23"},  # optional
     version_name="version_name",  # optional
     description="description",  # optional
 )
@@ -343,7 +343,7 @@ client = RoeClient()
 result = client.agents.versions.create(
     agent_id="agent_id",  # required
     input_definitions=[{"key": "text", "data_type": "text/plain"}],  # optional
-    engine_config={"model": "gpt-4.1"},  # optional
+    engine_config={"model": "gpt-5.5-2026-04-23"},  # optional
     version_name="version_name",  # optional
     description="description",  # optional
 )

--- a/examples/create_agent.py
+++ b/examples/create_agent.py
@@ -23,7 +23,7 @@ def main():
             },
         ],
         engine_config={
-            "model": "gpt-4.1-2025-04-14",
+            "model": "gpt-5.5-2026-04-23",
             "instruction": "Summarize the key points of this document.",
             "output_schema": {
                 "type": "object",

--- a/examples/manage_versions.py
+++ b/examples/manage_versions.py
@@ -28,7 +28,7 @@ def main():
             },
         ],
         engine_config={
-            "model": "gpt-4.1-2025-04-14",
+            "model": "gpt-5.5-2026-04-23",
             "instruction": "Extract structured data from the text.",
             "temperature": "0",
         },

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -918,7 +918,7 @@ paths:
                       accepts_multiple_files: null
                     engine_config:
                       text: ${text}
-                      model: gpt-4.1-2025-04-14
+                      model: gpt-5.5-2026-04-23
                       instruction: Process the text
                       temperature: '0.0'
                       output_schema: '{"type":"string","description":"The result"}'


### PR DESCRIPTION
## Summary

- Updates Python SDK README examples and example scripts to use `gpt-5.5-2026-04-23`.
- Updates generated `SDK_EXAMPLES.md` and the checked-in SDK OpenAPI snapshot from the regenerated roe-main SDK spec.
- Leaves the supported-model table entry for GPT-4.1 intact as a model catalog row, not an example default.

## Source / generation

- Propagated from roe-main `roe-sdk/dist/sdk-openapi.yml` with `uv run --locked python -m roe_sdk prepare-target --target python --repo /tmp/roe-sdk-model-prs-20260618/python --spec dist/sdk-openapi.yml --version 1.1.1`.
- Verified `openapi/openapi.yml` matches the regenerated root SDK spec exactly.

## Validation

- `git diff --check`
- `uv run --locked pytest -q`

## Related

- Source roe-main PR: https://github.com/roe-ai/roe-main/pull/3532
