### PR TITLE
Add skip_cache parameter to agent run methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `skip_cache=True` parameter on `client.agents.run(...)`, `run_many(...)`,
+  `run_sync(...)`, `run_version(...)`, and `run_version_sync(...)`. Sends the
+  `X-Skip-Cache: true` header so the backend bypasses the job-result cache and
+  forces a fresh run (the fresh result still refreshes the cache).
+  Note: `skip_cache` is now a reserved parameter name on these methods (like
+  `metadata` and `idempotency_key`); an agent input literally named
+  `skip_cache` can no longer be passed via `**inputs` — use `run_many`'s
+  dict-based inputs for such agents.
+
 ## 1.0.802
 
 Version synchronization across `roe-ai` (Python), `roe-typescript`,

--- a/README.md
+++ b/README.md
@@ -553,6 +553,11 @@ batch = client.agents.run_many(
     batch_inputs=[{"text": "input1"}, {"text": "input2"}]
 )
 results = batch.wait()
+
+# Skip the job-result cache and force a fresh run
+# (available on run, run_sync, run_many, run_version, run_version_sync;
+# the fresh result still refreshes the cache)
+job = client.agents.run(agent_id="uuid", skip_cache=True, text="input")
 ```
 
 ## Metadata

--- a/src/roe/api/agents.py
+++ b/src/roe/api/agents.py
@@ -102,6 +102,19 @@ from roe.utils._dynamic_call import call_dynamic
 from roe.utils.generated_request import request_json, request_raw
 
 
+def _build_run_headers(
+    idempotency_key: str | None = None,
+    skip_cache: bool = False,
+) -> dict[str, str] | None:
+    """Build the optional per-run request headers shared by the run methods."""
+    headers: dict[str, str] = {}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+    if skip_cache:
+        headers["X-Skip-Cache"] = "true"
+    return headers or None
+
+
 def _build_aer(inputs: dict[str, Any]) -> AgentExecutionRequest:
     """Pack a free-form ``inputs`` dict into an ``AgentExecutionRequest``.
 
@@ -585,9 +598,14 @@ class AgentsAPI:
         timeout_seconds: int | None = None,
         metadata: dict[str, Any] | None = None,
         idempotency_key: str | None = None,
+        skip_cache: bool = False,
         **inputs: Any,
     ) -> Job:
-        """Run an agent asynchronously and return a ``Job`` handle."""
+        """Run an agent asynchronously and return a ``Job`` handle.
+
+        Set ``skip_cache=True`` to bypass the job-result cache and force a
+        fresh run (the fresh result still refreshes the cache).
+        """
         response = call_dynamic(
             self._raw,
             agents_run_async_create,
@@ -595,9 +613,7 @@ class AgentsAPI:
             metadata=metadata,
             organization_id=self._org_id,
             agent_id=UUID(str(agent_id)),
-            extra_headers=(
-                {"Idempotency-Key": idempotency_key} if idempotency_key else None
-            ),
+            extra_headers=_build_run_headers(idempotency_key, skip_cache),
         )
         job_id = response.json()
         if not isinstance(job_id, str):
@@ -612,8 +628,13 @@ class AgentsAPI:
         batch_inputs: list[dict[str, Any]],
         timeout_seconds: int | None = None,
         metadata: dict[str, Any] | None = None,
+        skip_cache: bool = False,
     ) -> JobBatch:
-        """Run an agent across many inputs (JSON body, no multipart)."""
+        """Run an agent across many inputs (JSON body, no multipart).
+
+        Set ``skip_cache=True`` to bypass the job-result cache and force
+        fresh runs (the fresh results still refresh the cache).
+        """
         all_job_ids: list[str] = []
         is_first_chunk = True
         for chunk in self._iter_chunks(batch_inputs, self._MAX_BATCH_SIZE):
@@ -631,6 +652,7 @@ class AgentsAPI:
                 UUID(str(agent_id)),
                 body=body,
                 organization_id=self._org_id,
+                extra_headers=_build_run_headers(skip_cache=skip_cache),
             )
             chunk_ids = response.json()
             if not isinstance(chunk_ids, list):
@@ -649,9 +671,14 @@ class AgentsAPI:
         self,
         agent_id: str,
         metadata: dict[str, Any] | None = None,
+        skip_cache: bool = False,
         **inputs: Any,
     ) -> list[AgentDatum]:
-        """Run an agent synchronously and return the outputs."""
+        """Run an agent synchronously and return the outputs.
+
+        Set ``skip_cache=True`` to bypass the job-result cache and force a
+        fresh run (the fresh result still refreshes the cache).
+        """
         response = call_dynamic(
             self._raw,
             agents_run,
@@ -659,6 +686,7 @@ class AgentsAPI:
             metadata=metadata,
             organization_id=self._org_id,
             agent_id=UUID(str(agent_id)),
+            extra_headers=_build_run_headers(skip_cache=skip_cache),
         )
         return [AgentDatum.from_dict(d) for d in response.json()]
 
@@ -669,8 +697,14 @@ class AgentsAPI:
         timeout_seconds: int | None = None,
         metadata: dict[str, Any] | None = None,
         idempotency_key: str | None = None,
+        skip_cache: bool = False,
         **inputs: Any,
     ) -> Job:
+        """Run a specific agent version asynchronously and return a ``Job``.
+
+        Set ``skip_cache=True`` to bypass the job-result cache and force a
+        fresh run (the fresh result still refreshes the cache).
+        """
         response = call_dynamic(
             self._raw,
             agents_run_versions_async_create,
@@ -679,9 +713,7 @@ class AgentsAPI:
             organization_id=self._org_id,
             agent_id=UUID(str(agent_id)),
             agent_version_id=UUID(str(version_id)),
-            extra_headers=(
-                {"Idempotency-Key": idempotency_key} if idempotency_key else None
-            ),
+            extra_headers=_build_run_headers(idempotency_key, skip_cache),
         )
         job_id = response.json()
         if not isinstance(job_id, str):
@@ -695,8 +727,14 @@ class AgentsAPI:
         agent_id: str,
         version_id: str,
         metadata: dict[str, Any] | None = None,
+        skip_cache: bool = False,
         **inputs: Any,
     ) -> list[AgentDatum]:
+        """Run a specific agent version synchronously and return the outputs.
+
+        Set ``skip_cache=True`` to bypass the job-result cache and force a
+        fresh run (the fresh result still refreshes the cache).
+        """
         response = call_dynamic(
             self._raw,
             agents_run_version,
@@ -705,5 +743,6 @@ class AgentsAPI:
             organization_id=self._org_id,
             agent_id=UUID(str(agent_id)),
             agent_version_id=UUID(str(version_id)),
+            extra_headers=_build_run_headers(skip_cache=skip_cache),
         )
         return [AgentDatum.from_dict(d) for d in response.json()]

--- a/src/roe/utils/generated_request.py
+++ b/src/roe/utils/generated_request.py
@@ -20,6 +20,7 @@ def request_raw(
     ep_module: Any,
     *path_args: Any,
     body: Any = UNSET,
+    extra_headers: dict[str, str] | None = None,
     **kwargs: Any,
 ) -> Any:
     """Call a generated endpoint while forcing JSON body serialization."""
@@ -35,6 +36,9 @@ def request_raw(
         headers["Content-Type"] = "application/json"
     else:
         request_kwargs = ep_module._get_kwargs(*path_args, **kwargs)
+
+    if extra_headers:
+        request_kwargs.setdefault("headers", {}).update(extra_headers)
 
     response = raw.get_httpx_client().request(**request_kwargs)
     translate_response(response)

--- a/tests/unit/test_agents_wrapper_transport.py
+++ b/tests/unit/test_agents_wrapper_transport.py
@@ -74,6 +74,108 @@ def test_run_passes_idempotency_key_through_dynamic_wrapper():
     assert job.id == JOB_ID
 
 
+def test_run_passes_skip_cache_header_through_dynamic_wrapper():
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    job = api.run(AGENT_ID, skip_cache=True, prompt="hello")
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["headers"]["X-Skip-Cache"] == "true"
+    assert job.id == JOB_ID
+
+
+def test_run_omits_skip_cache_header_by_default():
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run(AGENT_ID, prompt="hello")
+
+    kwargs = request.call_args.kwargs
+    assert "X-Skip-Cache" not in kwargs["headers"]
+
+
+def test_run_sync_passes_skip_cache_header():
+    api, request = _api(httpx.Response(200, json=[]))
+
+    api.run_sync(AGENT_ID, skip_cache=True, prompt="hello")
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["headers"]["X-Skip-Cache"] == "true"
+
+
+def test_run_version_passes_skip_cache_and_idempotency_headers():
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run_version(
+        AGENT_ID,
+        VERSION_ID,
+        idempotency_key="idem-456",
+        skip_cache=True,
+        prompt="hello",
+    )
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["headers"]["Idempotency-Key"] == "idem-456"
+    assert kwargs["headers"]["X-Skip-Cache"] == "true"
+
+
+def test_run_version_sync_passes_skip_cache_header():
+    api, request = _api(httpx.Response(200, json=[]))
+
+    api.run_version_sync(AGENT_ID, VERSION_ID, skip_cache=True, prompt="hello")
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["headers"]["X-Skip-Cache"] == "true"
+
+
+def test_run_many_passes_skip_cache_header_on_json_batch():
+    api, request = _api(httpx.Response(200, json=[JOB_ID]))
+
+    batch = api.run_many(AGENT_ID, [{"prompt": "hello"}], skip_cache=True)
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["headers"]["X-Skip-Cache"] == "true"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert batch.job_ids == [JOB_ID]
+
+
+def test_run_many_omits_skip_cache_header_by_default():
+    api, request = _api(httpx.Response(200, json=[JOB_ID]))
+
+    api.run_many(AGENT_ID, [{"prompt": "hello"}])
+
+    kwargs = request.call_args.kwargs
+    assert "X-Skip-Cache" not in kwargs["headers"]
+
+
+def test_run_many_sends_skip_cache_header_on_every_chunk():
+    api, request = _api(httpx.Response(200, json=[JOB_ID]))
+
+    api.run_many(AGENT_ID, [{"prompt": "hello"}] * 1001, skip_cache=True)
+
+    assert request.call_count == 2
+    for call in request.call_args_list:
+        assert call.kwargs["headers"]["X-Skip-Cache"] == "true"
+
+
+def test_sync_and_version_runs_omit_skip_cache_header_by_default():
+    api, request = _api(httpx.Response(200, json=[]))
+
+    api.run_sync(AGENT_ID, prompt="hello")
+    api.run_version_sync(AGENT_ID, VERSION_ID, prompt="hello")
+
+    for call in request.call_args_list:
+        assert "X-Skip-Cache" not in call.kwargs["headers"]
+
+
+def test_run_version_omits_skip_cache_header_by_default():
+    api, request = _api(httpx.Response(200, json=JOB_ID))
+
+    api.run_version(AGENT_ID, VERSION_ID, prompt="hello")
+
+    kwargs = request.call_args.kwargs
+    assert "X-Skip-Cache" not in kwargs["headers"]
+
+
 def test_agent_replace_uses_put_with_org_query_and_model_body():
     api, request = _api(httpx.Response(200, json=_base_agent_json()))
 


### PR DESCRIPTION
## Summary

Adds `skip_cache=True` on all five agent run methods (`run`, `run_many`, `run_sync`, `run_version`, `run_version_sync`). When set, the SDK sends the `X-Skip-Cache: true` header so the backend bypasses the job-result cache lookup and forces a fresh run — the fresh result still refreshes the cache. The header is omitted entirely when the flag is off (matching the backend's exact-`"true"` parsing).

Requested for the TikTok integration; the header has existed backend-side but was previously unreachable from the SDK.

- `_build_run_headers()` merges `skip_cache` with the existing `Idempotency-Key` header plumbing (`call_dynamic` path)
- `request_raw()` gains an `extra_headers` pass-through for the JSON batch path; the header rides on every chunk of a chunked `run_many`
- Docstrings added to `run_version` / `run_version_sync`; README + CHANGELOG updated
- Note: `skip_cache` joins `metadata`/`idempotency_key` as a reserved parameter name — an agent input literally named `skip_cache` must use `run_many`'s dict inputs (called out in CHANGELOG)

## Test Plan

- [x] `uv run pytest tests/` — 66 passed (11 new cases: header present per method, absent by default per method, header on every chunk of a 1001-input batch)
- [x] `uv run ruff check src tests` — clean
- [x] Adversarial review pass (multi-agent): header contract verified against backend `should_skip_cache` parsing; merge order verified safe for `Content-Type`/`x-roe-skip-retry`; no other run entry points exist in the SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)