### PR TITLE
Implement resend_webhook on the agent jobs facade

### DIFF
--- a/src/roe/api/agents.py
+++ b/src/roe/api/agents.py
@@ -25,6 +25,7 @@ from roe._generated.api.agents import (
     agents_jobs_artifacts_result_retrieve,
     agents_jobs_cancel_all_create,
     agents_jobs_cancel_create,
+    agents_jobs_webhook_resend_create,
     agents_jobs_delete_data_create,
     agents_jobs_list,
     agents_jobs_references_retrieve,
@@ -57,6 +58,7 @@ from roe._generated.models.agent_execution_request import (
 from roe._generated.models.agent_job_artifact_result import AgentJobArtifactResult
 from roe._generated.models.agent_job_cancel_all_response import (
     AgentJobCancelAllResponse,
+    AgentJobWebhookResendResponse,
 )
 from roe._generated.models.agent_job_delete_data_response import (
     AgentJobDeleteDataResponse,
@@ -423,6 +425,21 @@ class AgentJobsAPI:
             UUID(str(job_id)),
             organization_id=self._org_id,
         )
+
+    def resend_webhook(self, job_id: str) -> AgentJobWebhookResendResponse:
+        """Re-send a finished job's completion webhook.
+
+        The job is not re-run and its status is unchanged. ``queued`` reports
+        how many deliveries were queued; zero means the agent has no active
+        webhook.
+        """
+        response = request_raw(
+            self._raw,
+            agents_jobs_webhook_resend_create,
+            UUID(str(job_id)),
+            organization_id=self._org_id,
+        )
+        return AgentJobWebhookResendResponse.from_dict(response.json())
 
     def cancel_all(self, agent_id: str) -> AgentJobCancelAllResponse:
         response = request_raw(

--- a/src/roe/api/agents.py
+++ b/src/roe/api/agents.py
@@ -59,6 +59,9 @@ from roe._generated.models.agent_job_artifact_result import AgentJobArtifactResu
 from roe._generated.models.agent_job_cancel_all_response import (
     AgentJobCancelAllResponse,
 )
+from roe._generated.models.resend_agent_job_webhook_request import (
+    ResendAgentJobWebhookRequest,
+)
 from roe._generated.models.agent_job_delete_data_response import (
     AgentJobDeleteDataResponse,
 )
@@ -428,17 +431,24 @@ class AgentJobsAPI:
             organization_id=self._org_id,
         )
 
-    def resend_webhook(self, job_id: str) -> AgentJobWebhookResendResponse:
+    def resend_webhook(
+        self, job_id: str, webhook_id: str | None = None
+    ) -> AgentJobWebhookResendResponse:
         """Re-send a finished job's completion webhook.
 
-        The job is not re-run and its status is unchanged. ``queued`` reports
-        how many deliveries were queued; zero means the agent has no active
-        webhook.
+        Sends to every webhook attached to the job's agent, or only to
+        ``webhook_id`` when given. The job is not re-run and its status is
+        unchanged. ``queued`` reports how many deliveries were queued; zero
+        means nothing was eligible.
         """
+        body = ResendAgentJobWebhookRequest(
+            webhook_id=UUID(str(webhook_id)) if webhook_id is not None else UNSET,
+        )
         response = request_raw(
             self._raw,
             agents_jobs_webhook_resend_create,
             UUID(str(job_id)),
+            body=body,
             organization_id=self._org_id,
         )
         return AgentJobWebhookResendResponse.from_dict(response.json())

--- a/src/roe/api/agents.py
+++ b/src/roe/api/agents.py
@@ -58,10 +58,12 @@ from roe._generated.models.agent_execution_request import (
 from roe._generated.models.agent_job_artifact_result import AgentJobArtifactResult
 from roe._generated.models.agent_job_cancel_all_response import (
     AgentJobCancelAllResponse,
-    AgentJobWebhookResendResponse,
 )
 from roe._generated.models.agent_job_delete_data_response import (
     AgentJobDeleteDataResponse,
+)
+from roe._generated.models.agent_job_webhook_resend_response import (
+    AgentJobWebhookResendResponse,
 )
 from roe._generated.models.agent_job_result_many_request import (
     AgentJobResultManyRequest,

--- a/tests/unit/test_agents_wrapper_transport.py
+++ b/tests/unit/test_agents_wrapper_transport.py
@@ -275,6 +275,18 @@ def test_cancel_all_returns_structured_response_body():
     assert result.note == "cancelling"
 
 
+def test_resend_webhook_posts_to_the_job_and_returns_queued_count():
+    api, request = _api(httpx.Response(200, json={"status": "queued", "queued": 2}))
+
+    result = api.jobs.resend_webhook(JOB_ID)
+
+    kwargs = request.call_args.kwargs
+    assert kwargs["method"] == "post"
+    assert kwargs["url"].endswith(f"/v1/agents/jobs/{JOB_ID}/webhook/resend/")
+    assert kwargs["params"] == {"organization_id": ORG_ID}
+    assert result.queued == 2
+
+
 def test_retrieve_status_parses_single_status_shape_without_id():
     # GET /v1/agents/jobs/{job_id}/status/ returns AgentJobSingleStatus
     # ({status, timestamp, error_message?}) with no "id" field — parsing it


### PR DESCRIPTION
The v1.0.93 release (#71) shipped the generated endpoint module and an SDK_EXAMPLES entry for `client.agents.jobs.resend_webhook`, but the hand-written `AgentJobsAPI` facade has no such method — following the documented example raises `AttributeError` before any request is sent.

This adds the facade method, mirroring `cancel_all`: it calls the generated `agents_jobs_webhook_resend_create` endpoint and returns the `AgentJobWebhookResendResponse` model (`queued` reports how many deliveries were queued; zero means the agent has no active webhook).

Flagged by Greptile on #71, which had already merged by the time the fix was ready — hence this follow-up against main rather than a push to the release branch.

### Test Plan
- [x] `python -m py_compile` on the changed module
- [ ] CI (lint / test / codegen-drift) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)